### PR TITLE
Add .gitattributes for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+#
+# How to handle line endings
+# Start with a default: text=auto will cover binary files as well
+# However, we can speed up things a little bit by pointing out known
+# known file types as binary
+#
+*      text=auto
+*.bat  text eol=crlf
+*.jpeg -text
+*.png  -text
+*.sh   text eol=lf
+*.svg  -text


### PR DESCRIPTION
Currently some .rst files are committed with CRLF, others with LF. This is not going to change now.
However, when adding new .rst files, they will be commited with LF into the repo.
When checking out them under windows, they will get CRLF in the working tree (your hard disk)