### PR TITLE
Pin the version of sphinx-rtd-theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,11 @@ sphinx:
 #mkdocs:
 #  configuration: mkdocs.yml
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 python:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 sphinx_copybutton
 sphinx-hoverxref
-myst-parser
-sphinx-rtd-theme
+myst-parser==2.0.0
+sphinx-rtd-theme==1.3.0
+sphinx==7.2.4
 sphinx-autobuild

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 sphinx_copybutton
 sphinx-hoverxref
-myst-parser
+myst-parser==2.0.0
+sphinx-rtd-theme==1.3.0
+sphinx==7.2.4


### PR DESCRIPTION
This forces pinning of sphinx-rtd-theme (as well as a few other basic packages) to make sure that the styling is consistent with local builds.