### PR TITLE
Include "Configure Channel Access" and "How to Make Channel Access Reach Multiple Soft IOCs on a Linux Host"

### DIFF
--- a/getting-started/channel-access-reach-multiple-soft-iocs-linux.md
+++ b/getting-started/channel-access-reach-multiple-soft-iocs-linux.md
@@ -1,0 +1,101 @@
+# How to Make Channel Access Reach Multiple Soft IOCs on a Linux Host
+
+## UDP Name Resolution: Broadcast vs. Unicast
+
+Running multiple IOCs on one host has an annoying side effect: Clients that are using that host's IP address in their `EPICS_CA_ADDR_LIST` with `EPICS_CA_AUTO_ADDR_LIST=NO` will only reach one of the IOCs – usually the one that was started last. All clients have to use broadcasts to reach all IOCs.
+
+The same is true for CA Gateway machines that are set up in a way that makes multiple Gateway processes serve channels into the same network.
+
+The reason is that the kernel delivers UDP broadcasts to _all_ processes that are listening to the IP port, while UDP unicast messages will only be delivered to _one_ of those processes.
+
+## Fix Using iptables
+
+Here's a little helper (for Linux hosts) that I recently was playing around with – based on an idea by Rodrigo Bongers (CNPEM, Brazil).
+
+If you drop the right script in the right place (depending on your Linux distribution, see further down), it will automatically create/delete an iptables rule that replaces the destination address of all incoming CA UDP traffic on each interface with the broadcast address of that interface.
+
+A simple and effective trick: the kernel will see all incoming name resolution requests as broadcasts, and delivers them to all IOCs instead of one.
+
+Note: This will not work for clients on the same host. (Adding that feature makes things a lot more complicated, and I like things to be simple.)
+
+If you need connections between IOCs on one host, I would suggest adding the broadcast address of the loopback interface (usually `127.255.255.255`) to each IOC's `EPICS_CA_ADDR_LIST` setting.
+
+### On Debian and Derivatives
+
+Drop/link the following script into `/etc/network/if-up.d/` and `/etc/network/if-down.d/`.
+If your system does not have the ip command, consider updating it (or install package iproute2 from backports).
+
+``` sh
+#!/bin/sh -e
+# Called when an interface goes up / down
+
+# Author: Ralph Lange <Ralph.Lange@gmx.de>
+
+# Make any incoming Channel Access name resolution queries go to the broadcast address
+# (to hit all IOCs on this host)
+
+# Change this if you run CA on a non-standard port
+PORT=5064
+
+[ "$METHOD" != "none" ] || exit 0
+[ "$IFACE" != "lo" ] || exit 0
+
+line=`ip addr show $IFACE`
+addr=`echo $line | grep -Po 'inet \K[\d.]+'`
+bcast=`echo $line | grep -Po 'brd \K[\d.]+'`
+[ -z "$addr" -o -z "$bcast" ] && return 1
+
+if [ "$MODE" = "start" ]
+then
+    iptables -t nat -A PREROUTING -d $addr -p udp --dport $PORT -j DNAT --to-destination $bcast
+elif [ "$MODE" = "stop" ]
+then
+    iptables -t nat -D PREROUTING -d $addr -p udp --dport $PORT -j DNAT --to-destination $bcast
+fi
+
+exit 0
+```
+
+### On RedHat and Derivatives
+
+On systems using NetworkManager, drop the script below into `/etc/NetworkManager/dispatcher.d/`. The rules for these files are:
+
+> NetworkManager will execute scripts in the /etc/NetworkManager/dispatcher.d directory in alphabetical order in response to network events. Each script should be (a) a regular file, (b) owned by root, \(c\) not writable by group or other, (d) not set-uid, (e) and executable by the owner. Each script receives two arguments, the first being the interface name of the device just activated, and second an action.
+
+``` sh
+#!/bin/sh -e
+# Called when an interface goes up / down
+
+# Author: Ralph Lange <Ralph.Lange@gmx.de>
+
+# Make any incoming Channel Access name resolution queries go to the broadcast address
+# (to hit all IOCs on this host)
+
+# Change this if you run CA on a non-standard port
+PORT=5064
+
+IFACE=$1
+MODE=$2
+
+[ "$IFACE" != "lo" ] || exit 0
+
+line=`/sbin/ip addr show $IFACE`
+addr=`echo $line | grep -Po 'inet \K[\d.]+'`
+bcast=`echo $line | grep -Po 'brd \K[\d.]+'`
+
+[ -z "$addr" -o -z "$bcast" ] && return 1
+
+if [ "$MODE" = "up" ]
+then
+    /sbin/iptables -t nat -A PREROUTING -d $addr -p udp --dport $PORT -j DNAT --to-destination $bcast
+elif [ "$MODE" = "down" ]
+then
+    /sbin/iptables -t nat -D PREROUTING -d $addr -p udp --dport $PORT -j DNAT --to-destination $bcast
+fi
+
+exit 0
+```
+
+Enjoy!  
+Ralph
+

--- a/getting-started/configure-ca.md
+++ b/getting-started/configure-ca.md
@@ -20,7 +20,7 @@ The default broadcast name search is limited to the subnet of the computer runni
 
 When starting the first IOC on a computer, it will listen to name searches on UDP port 5064. When starting a second IOC on the same computer, it will also listen to name searches on UDP port 5064. Due to limitations in most network kernels, however, only the IOC started _last_ will actually receive UDP search requests that are sent to that computer, port 5064. As a workaround, you need to configure the `EPICS_CA_ADDR_LIST` to use the broadcast address of the respective subnet.
 
-Alternatively, you can automatically set up iptables rules that will circumvent the problem. (See [How to Make Channel Access Reach Multiple Soft IOCs on a Linux Host](https://epics-controls.org/resources-and-support/documents/howto-documents/channel-access-reach-multiple-soft-iocs-linux/).)
+Alternatively, you can automatically set up iptables rules that will circumvent the problem. (See [How to Make Channel Access Reach Multiple Soft IOCs on a Linux Host](channel-access-reach-multiple-soft-iocs-linux).)
 
 ## Multiple IOCs on the same computer but on a different subnet
 

--- a/guides/configure-ca.md
+++ b/guides/configure-ca.md
@@ -1,0 +1,49 @@
+# How to Configure Channel Access
+
+## Basic Operation, One IOC on same subnet
+
+Assume an IOC has a record `fred`, and you want to use `caget fred` or a similar CA client to read it.
+
+When starting out with one IOC on the network, things are simple:
+
+CA clients will by default broadcast name search requests to UDP port 5064 on the subnet. As long as the IOC is running on on any computer on that subnet, it should receive those search requests. Server and client will then establish a TCP connection, and data is exchanged.
+
+## Multiple IOCs on different computers, but same subnet
+
+If running multiple IOCs, each on their own computer, on the same subnet, the basic broadcast name search will still succeed, no change necessary.
+
+## IOCs on different subnets
+
+The default broadcast name search is limited to the subnet of the computer running the CA client. To reach IOCs on one or more additional subnets, the environment variable `EPICS_CA_ADDR_LIST` needs to be configured. It can list either the specific IP addresses of each IOC, or the broadcast address of their subnet. Note, however, that routers will often not forward broadcast requests, which suggests using specific IP addresses.
+
+## Multiple IOCs on the same computer
+
+When starting the first IOC on a computer, it will listen to name searches on UDP port 5064. When starting a second IOC on the same computer, it will also listen to name searches on UDP port 5064. Due to limitations in most network kernels, however, only the IOC started _last_ will actually receive UDP search requests that are sent to that computer, port 5064. As a workaround, you need to configure the `EPICS_CA_ADDR_LIST` to use the broadcast address of the respective subnet.
+
+Alternatively, you can automatically set up iptables rules that will circumvent the problem. (See [How to Make Channel Access Reach Multiple Soft IOCs on a Linux Host](https://epics-controls.org/resources-and-support/documents/howto-documents/channel-access-reach-multiple-soft-iocs-linux/).)
+
+## Multiple IOCs on the same computer but on a different subnet
+
+Combining the last two points results in a problem: To reach multiple IOCs on the same computer, `EPICS_CA_ADDR_LIST` must be set to the broadcast address of that computer's subnet. If the IOCs' subnet is different from the CA client's subnet however, the broadcast search packets will not usually be forwarded by the intermediate network routers.
+
+There are several options to solve this:
+
+### Channel Access Gateway
+
+The PV gateway, running on the subnet that has the desired IOCs, will use the broadcast address of that subnet in its `EPICS_CA_ADDR_LIST`, so it can reach all IOCs, including multiple IOCs running on the same computer, throughout that subnet. A CA client on a different subnet uses only `EPICS_CA_ADDR_LIST=ip-of-the-gateway` to directly reach the gateway, which is possible via routers.
+
+In addition to establishing the basic connectivity, the gateway also offers IOC load reduction and it can add access security, for example limit write access.
+
+### CA Nameserver
+
+You can run a CA Name Server in the GUI subnet which knows about the IOCs and responds to search requests; in this case you would _not_ set the `EPICS_CA_ADDR_LIST` variables. This is almost equivalent to running a CA Gateway, but is slightly more robust because if the Nameserver process dies it wouldn't kill any existing connections.
+
+### UDP Broadcast Packet Relay
+
+If you have access to a machine with a network interface on both subnets you can run a program on it called [UDP Broadcast Packet Relay](https://www.joachim-breitner.de/udp-broadcast-relay/) to forward UDP broadcast packets between the subnets. For best performance you should run it twice, once for port 5064 and again for 5065. The first one will forward CA search requests between the subnets, while the second redistributes CA beacons which help channels reconnect faster after an IOC has been turned off for some time.
+
+## Firewalls
+
+Firewalls may need to be configured to pass UDP and TCP traffic on both ports 5064 and 5065.
+
+The [Channel Access Reference Manual](https://epics.anl.gov/base/R7-0/7-docs/CAref.html) provides a lot more detail.

--- a/index.rst
+++ b/index.rst
@@ -48,6 +48,9 @@ There are two kinds of subprojects:
    getting-started/creating-ioc
    getting-started/installation-windows
    getting-started/save-restore-tools.md
+   getting-started/configure-ca
+   getting-started/channel-access-reach-multiple-soft-iocs-linux
+
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Both pages copied form https://epics-controls.org
Included both at same type as "Configure Channel Access" link to "How to Make Channel Access Reach Multiple Soft IOCs on a Linux Host"