### PR TITLE
Add extra labels configuration to indicate the audience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,24 @@ For example:
 
   [Diátaxis documentation]: https://diataxis.fr/
 
+
+##### Labeling the document
+
+To suggest the intended audience, we provide a mechanism to label documents.
+There are `beginner`, `user`, `developer`, `advanced` and `all` roles.
+
+To label the article,
+add line specifying labels under the title in the new `.rst` file
+for example:
+
+``` 
+:audience:`beginner, user, developer`
+```
+
+After you create the new document,
+please add it under the toctree of `index_*.rst`.
+If it contains the right role, it will be included in right index file.
+
 #### Forking the repository
 
 Once logged in and viewing the page on GitHub you wish to edit,

--- a/access-security/specifications.rst
+++ b/access-security/specifications.rst
@@ -2,6 +2,8 @@
 IOC Access Security
 ===================
 
+:audience:`developer, advanced`
+
 .. contents:: Table of Contents
  :depth: 3
 

--- a/appdevguide/AccessSecurity.rst
+++ b/appdevguide/AccessSecurity.rst
@@ -2,6 +2,8 @@
 IOC Access Security
 ===================
 
+:audience:`developer, advanced`
+
 .. contents:: Table of Contents
  :depth: 3
 

--- a/appdevguide/AppDevGuide.rst
+++ b/appdevguide/AppDevGuide.rst
@@ -1,6 +1,8 @@
 Application Developer's Guide
 =============================
 
+:audience:`developer, advanced`
+
 The classic Application Developer's Guide as an online document.
 At this stage, this contains only the descriptive sections of the document,
 detailed API documentation will be generated from the source code with Doxygen.

--- a/appdevguide/IOCInit.rst
+++ b/appdevguide/IOCInit.rst
@@ -1,6 +1,8 @@
 IOC Initialization
 ------------------
 
+:audience:`developer`
+
 .. contents:: Table of Contents
  :depth: 3
 

--- a/appdevguide/IOCTestFacilities.rst
+++ b/appdevguide/IOCTestFacilities.rst
@@ -1,6 +1,8 @@
 IOC Test Facilities
 ===================
 
+:audience:`user, developer`
+
 .. contents:: Table of Contents
  :depth: 3
 

--- a/appdevguide/databaseDefinition.rst
+++ b/appdevguide/databaseDefinition.rst
@@ -1,6 +1,9 @@
 Database Definition
 ===================
 
+:audience:`developer, advanced`
+
+
 Overview
 --------
 

--- a/appdevguide/gettingStarted.rst
+++ b/appdevguide/gettingStarted.rst
@@ -1,6 +1,9 @@
 Getting Started
 ===============
 
+:audience:`beginner, user, developer`
+
+
 Introduction
 ------------
 

--- a/build-system/configuring-vxworks-6_x.md
+++ b/build-system/configuring-vxworks-6_x.md
@@ -1,5 +1,7 @@
 # Configuring vxWorks 6.x
 
+{audience}`user, advanced`
+
 ## vxWorks 6.x Information
 
 This page provides a advice on configuring and using the Wind River’s Workbench environment and the vxWorks 6.x RTOS with EPICS. If you discover any other information that ought to be published here, please [let me know](mailto:anj@anl.dot.gov).

--- a/build-system/cross-compile-epics-and-a-ioc-to-an-old-x86-linux.md
+++ b/build-system/cross-compile-epics-and-a-ioc-to-an-old-x86-linux.md
@@ -1,5 +1,7 @@
 # How To cross compile EPICS and a IOC to an old x86 Linux system
 
+{audience}`user, advanced`
+
 ## Introduction
 
 I was given the task of developing a IOC which should run in a x86 PC with an old Linux distribution.

--- a/build-system/how-to-port-epics-to-a-new-os-architecture.rst
+++ b/build-system/how-to-port-epics-to-a-new-os-architecture.rst
@@ -1,6 +1,8 @@
 How To Port EPICS to a new OS/Architecture
 ==========================================
 
+:audience:`user`
+
 This isn’t a detailed list of tasks, but is intended to show the main stages needed to add a new build architecture to EPICS. 
 If you make use of this and find there are hints you’d like to suggest, or steps missing please add them.
 

--- a/build-system/specifications.rst
+++ b/build-system/specifications.rst
@@ -1,6 +1,8 @@
 Build Facility
 --------------
 
+:audience:`developer`
+
 .. contents:: Table of Contents
  :depth: 3
 

--- a/build-system/vxworks6_tornado.md
+++ b/build-system/vxworks6_tornado.md
@@ -1,5 +1,7 @@
 # Configuring Tornado/vxWorks 5.5.x
 
+{audience}`user`
+
 ## Tornado/vxWorks 5.5.x Information
 
 This page provides a repository for information about using the WRS Tornado environment and the vxWorks 5.5.x RTOS with EPICS that doesn’t really belong anywhere else on this site.

--- a/community/how-to-run-an-epics-collaboration-meeting.rst
+++ b/community/how-to-run-an-epics-collaboration-meeting.rst
@@ -1,6 +1,8 @@
 How to run an EPICS Collaboration Meeting
 =========================================
 
+:audienece:`user, developer, advanced`
+
 This page is intended for “lessons learned” by sites who have run collaboration meetings, as hints to help future meetings run smoothly.
 
 .. toctree::

--- a/conf.py
+++ b/conf.py
@@ -143,7 +143,7 @@ html_logo = "images/EPICS_green_logo.svg"
 
 extra_labels = {
     'audience': {
-        'allowed_values': ['advanced', 'developers', 'users', 'beginners', 'all'],
+        'allowed_values': ['advanced', 'developer', 'user', 'beginner', 'all'],
         'visible': True,
         'label': 'Intended audience: ',
     }

--- a/conf.py
+++ b/conf.py
@@ -35,6 +35,8 @@ extensions = [
     "sphinx_reredirects",
     # Markdown parser
     'myst_parser',
+    'epics_docs_ext.extra_labels'
+    # 'epics_docs_ext.audience'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -137,4 +139,13 @@ redirects = {
     
     #"appdevguide/*": "appdevguide/*",
 }
+
 html_logo = "images/EPICS_green_logo.svg"
+
+extra_labels = {
+    'audience': {
+        'allowed_values': ['advanced', 'developers', 'users', 'beginners', 'all'],
+        'visible': True,
+        'label': 'Intended audience: ',
+    }
+}

--- a/conf.py
+++ b/conf.py
@@ -36,7 +36,6 @@ extensions = [
     # Markdown parser
     'myst_parser',
     'epics_docs_ext.extra_labels'
-    # 'epics_docs_ext.audience'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/contributing/HowToWorkWithTheEpicsRepository.rst
+++ b/contributing/HowToWorkWithTheEpicsRepository.rst
@@ -1,6 +1,8 @@
 How to Work with the EPICS Repository
 =====================================
 
+:audience:`beginner, user, developer, advanced, all`
+
 This document aims to show to software developers how to get the current
 EPICS Base code, modify it and publish the changes.
 

--- a/epics_docs_ext/extra_labels.py
+++ b/epics_docs_ext/extra_labels.py
@@ -1,0 +1,73 @@
+from docutils import nodes
+from docutils.parsers.rst.roles import set_classes
+
+def extra_label_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """
+    Specific labels role for EPICS Documentation
+
+    Returns tuple containing list of nodes to insert into the
+    document and a list of system messages.
+
+    :param name: The role name used in the document.
+    :param rawtext: The entire markup snippet, with role.
+    :param text: The text marked with the role.
+    :param lineno: The line number where rawtext appears in the input.
+    :param inliner: The inliner instance that called us.
+    :param options: Directive options for customization.
+    :param content: The directive content for customization.
+    """
+    try:
+        extra_labels = inliner.document.settings.env.app.config.extra_labels
+        assert isinstance(extra_labels, dict)
+    
+        label_config = extra_labels.get(name)
+        assert isinstance(label_config, dict)
+        set_classes(options)
+    
+        node = nodes.emphasis(rawtext='', text='', **options)
+        node['classes'].append('extra-label')
+
+        node_1 = nodes.strong(raw=rawtext, text=label_config.get('label', name), **options)
+        node_1['classes'].append('label')
+        
+        node_2 = nodes.emphasis(rawtext=rawtext, text=text, **options)
+
+        node += node_1
+        node += node_2
+
+        env = inliner.document.settings.env
+        if not hasattr(env, "doc_extralabels"):
+            extralabel = dict()
+            extralabel[env.docname] = dict()
+
+            extralabel[env.docname][name] = [text]
+            setattr(env, "doc_extralabels", extralabel)
+
+        if env.docname not in env.doc_extralabels:
+            env.doc_extralabels[env.docname] = dict()
+
+        env.doc_extralabels[env.docname][name] = [text.strip() for text
+                                                 in text.split(",")]
+    except AssertionError:
+        msg = inliner.reporter.error(
+            'Cannot create label "%s". Please check "extra_labels" in conf.py' % name, line=lineno)
+        prb = inliner.problematic(rawtext, rawtext, msg)
+        return [prb], [msg]
+
+    return [node, ], []
+
+
+def setup(app):
+    """Install the plugin
+
+    :param app: Sphinx application context.
+    """
+    app.add_config_value('extra_labels', None, 'env')
+
+    extra_labels = app.config._raw_config.get('extra_labels', {})
+    assert isinstance(extra_labels, dict)
+
+    for key in extra_labels.keys():
+        app.add_role(key, extra_label_role)
+
+    return {'version': '0.1.0'}

--- a/epics_docs_ext/extra_labels.py
+++ b/epics_docs_ext/extra_labels.py
@@ -107,7 +107,6 @@ class ExtraLabelTree(TocTree):
 
         return result
 
-
 def filtered_process(app, doctree, docname):
     """
     Filter the entries in the toctree for specific extra labels
@@ -147,7 +146,7 @@ def filtered_process(app, doctree, docname):
         for ent in entries:
             ent_name = ent[1]
 
-            if ent_name in env.doc_extralabels:
+            if hasattr(env, 'doc_extralabels') and ent_name in env.doc_extralabels:
                 ent_extralabels = env.doc_extralabels[ent_name]
 
                 _add = [False for _ in range(len(_filter.keys()))]

--- a/epics_docs_ext/extra_labels.py
+++ b/epics_docs_ext/extra_labels.py
@@ -1,6 +1,12 @@
 from docutils import nodes
 from docutils.parsers.rst.roles import set_classes
 
+from sphinx.directives.other import TocTree, int_or_nothing
+from docutils.parsers.rst import directives
+from sphinx import addnodes
+from copy import deepcopy
+
+
 def extra_label_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """
     Specific labels role for EPICS Documentation
@@ -57,8 +63,152 @@ def extra_label_role(name, rawtext, text, lineno, inliner, options={}, content=[
     return [node, ], []
 
 
+class ExtraLabelTree(TocTree):
+    """
+    Extended Toc Tree class to allow filtering by the extra labels specified
+    Directive extends the base Sphinx TocTree class.
+    Add information about the meta label used in the document.
+    Feature this work as a filter, that shows only this
+    document that has the specific meta lebel in the content.
+    """
+
+    option_spec = {
+        'maxdepth': int,
+        'name': directives.unchanged,
+        'caption': directives.unchanged_required,
+        'glob': directives.flag,
+        'hidden': directives.flag,
+        'includehidden': directives.flag,
+        'numbered': int_or_nothing,
+        'titlesonly': directives.flag,
+        'reversed': directives.flag,
+        # add new filter options, it uses python notation
+        # e.q {"audience": ["administrators", "all"]}
+        'extralabel': str
+    }
+
+    def run(self):
+        result = super(ExtraLabelTree, self).run()
+
+        if "extralabel" not in self.options:
+            return result
+
+        env = self.state.document.settings.env
+        if not hasattr(env, 'tocs_extralabel'):
+            env.tocs_extralabel = dict()
+
+        toc_extralabel = eval(self.options["extralabel"])
+        env.tocs_extralabel[env.docname] = toc_extralabel
+
+        for node in result:
+            if hasattr(node, 'traverse'):
+                for toctree_node in node.traverse(addnodes.toctree, include_self=True, siblings=True):
+                    toctree_node['extralabel'] = toc_extralabel
+
+        return result
+
+
+def filtered_process(app, doctree, docname):
+    """
+    Filter the entries in the toctree for specific extra labels
+
+    :param app: reference to the Sphinx application
+    :param doctree: reference to the resolved doctree
+    :param docname: name of the resolved document
+    :return:
+    """
+    env = app.builder.env
+    builder = app.builder
+    if not hasattr(env, 'tocs'):
+        return
+
+    if not hasattr(env, 'tocs_extralabel'):
+        return
+
+    def _filter_all_toctrees():
+        """"
+        Method used to filter all toctrees that use ExtraLabelTree features
+        """
+        for toc_name, _filter in env.tocs_extralabel.items():
+            toctree = env.tocs[toc_name][0][1][0]
+            _filter_the_toctree(toctree, _filter)
+
+    def _filter_the_toctree(toctree, _filter):
+        """
+        Method used to filter specific toctrees
+
+        :param toctree: the toctree to filter
+        :param _filter: the configuration dict use to filtering
+        :return:
+        """
+        entries = toctree["entries"]
+        parsed_entries = []
+
+        for ent in entries:
+            ent_name = ent[1]
+
+            if ent_name in env.doc_extralabels:
+                ent_extralabels = env.doc_extralabels[ent_name]
+
+                _add = [False for _ in range(len(_filter.keys()))]
+                index = 0
+
+                for index, key in enumerate(_filter.keys()):
+                    filter_values = _filter[key]
+                    if type(filter_values) is not list:
+                        filter_values = [filter_values]
+
+                    for filter_value in filter_values:
+                        try:
+                            if filter_value in ent_extralabels[key]:
+                                _add[index] = True
+                                break
+                        except KeyError:
+                            break
+
+                if all(_add):
+                    parsed_entries.append((None, ent_name))
+
+        toctree["entries"] = parsed_entries
+
+    if docname.__eq__(env.config.master_doc):
+        _filter_all_toctrees()
+
+    elif docname in env.tocs_extralabel.keys():
+        # make backup of already parsed ToC, before we modify it
+        tocs_origin = deepcopy(env.tocs)
+
+        # process toctrees in the doc
+        for toctree in doctree.traverse(addnodes.toctree):
+            label = toctree['extralabel']
+            # filter this toctree and all ist subtrees.
+            _filter_the_toctree(toctree, label)
+            for subtoctree in toctree.traverse(addnodes.toctree,
+                                               include_self=False,
+                                               siblings=True):
+                _filter_the_toctree(subtoctree, label)
+
+            # filter all other tocs entries
+            for doc, toc in env.tocs.items():
+                for subtoctree in toc.traverse(addnodes.toctree,
+                                               include_self=False,
+                                               siblings=True):
+                    _filter_the_toctree(subtoctree, label)
+
+            # resolve toctree to bullet list and replace it
+            # to avoid default processing
+            result = env.resolve_toctree(docname, builder, toctree)
+            if result is None:
+                toctree.replace_self([])
+            else:
+                toctree.replace_self(result)
+
+        # revert ToC from backup
+        env.tocs = tocs_origin
+
+
 def setup(app):
-    """Install the plugin
+    """Install the plugin.
 
     :param app: Sphinx application context.
     """
@@ -69,5 +219,8 @@ def setup(app):
 
     for key in extra_labels.keys():
         app.add_role(key, extra_label_role)
+
+    directives.register_directive('toctree', ExtraLabelTree)
+    app.connect("doctree-resolved", filtered_process)
 
     return {'version': '0.1.0'}

--- a/getting-started/EPICS_Intro.rst
+++ b/getting-started/EPICS_Intro.rst
@@ -1,6 +1,8 @@
 Getting started with EPICS
 ==========================
 
+:audience:`beginner`
+
 What is EPICS?
 --------------
 

--- a/getting-started/creating-ioc.rst
+++ b/getting-started/creating-ioc.rst
@@ -1,6 +1,8 @@
 Creation of an Input/Output Controller (IOC)
 ============================================
 
+:audience:`user, developer`
+
 An IOC allows to talk to devices e.g. via ethernet. Create a directory for
 the IOCs. For example ``$HOME/EPICS/IOCs``
 

--- a/getting-started/installation-windows.rst
+++ b/getting-started/installation-windows.rst
@@ -2,6 +2,8 @@
 Installation on Windows
 =======================
 
+:audience:`beginner`
+
 Introduction
 ------------
 

--- a/getting-started/installation.rst
+++ b/getting-started/installation.rst
@@ -1,6 +1,8 @@
 Installation on Linux/UNIX/DARWIN (Mac)
 =======================================
 
+:audience:`beginner`
+
 What is EPICS about?
 -----------------------------------
 We assume that you know more or less what EPICS is. Here we want to start

--- a/getting-started/linux-packages.rst
+++ b/getting-started/linux-packages.rst
@@ -1,6 +1,8 @@
 Packages required for EPICS on Centos 8
 =======================================
 
+:audience:`beginner`
+
 .. contents:: Contents
 
 

--- a/index.rst
+++ b/index.rst
@@ -1,38 +1,6 @@
 EPICS Documentation
 ===================
 
-This is the parent project for all EPICS related documentation on read-the-docs.
-
-A good part of the EPICS documentation is dynamically created and hosted by
-`read-the-docs <https://readthedocs.org>`_, which acts as a CI system, building
-and hosting documentation from source or dedicated documentation repositories.
-
-Read-the-docs offers valuable features that we use:
-
-- Keeps complete frozen documentation trees of all released versions under a
-  permalink with the release number.
-- Keeps the documentation of the development tree (usually 'master') up-to-date
-  and accessible using 'latest' as release number.
-- Switching versions is available through the web browser.
-
-This parent project page is not directly linked from the EPICS web site.
-It creates the link to the canonical URL https://docs.epics-controls.org -
-links from the EPICS web site to the documentation should point to the
-subprojects using the canonical URL, e.g.,
-'https://docs.epics-controls.org/projects/<project-slug>'
-
-There are two kinds of subprojects:
-
-1. Code repositories:
-   The documentation is created from comments in the source code (Javadoc or
-   Doxygen) and separate documents (PDF, Markdown, restructuredText).
-   Documentation trees of released versions are kept for reference.
-
-2. Documentation repositories:
-   The repositories contain only documentation (like FAQs and How-To-Pages).
-   Usually only one version exists ('latest').
-
-
 How this documentation is organized
 -----------------------------------
 
@@ -40,13 +8,13 @@ Each page is labeled by the intended audienece.
 You may also directly use related links to see documents which match you the most.
 
     +------------------------+----------------------------------------------------------------------+
-    | **Beginner**           | :ref:`Index<beginner_docs>`                                          |
+    | **Beginner**           | :ref:`For beginners<beginner_docs>`                                  |
     +------------------------+----------------------------------------------------------------------+
-    | **User**               | :ref:`Index<user_docs>`                                              |
+    | **User**               | :ref:`For users<user_docs>`                                          |
     +------------------------+----------------------------------------------------------------------+
-    | **Developer**          | :ref:`Index<developer_docs>`                                         |
+    | **Developer**          | :ref:`For developers<developer_docs>`                                |
     +------------------------+----------------------------------------------------------------------+
-    | **Advanced**           | :ref:`Index<advanced_docs>`                                          |
+    | **Advanced**           | :ref:`For advanced<advanced_docs>`                                   |
     +------------------------+----------------------------------------------------------------------+
 
 

--- a/index.rst
+++ b/index.rst
@@ -33,6 +33,23 @@ There are two kinds of subprojects:
    Usually only one version exists ('latest').
 
 
+How this documentation is organized
+-----------------------------------
+
+Each page is labeled by the intended audienece.
+You may also directly use related links to see documents which match you the most.
+
+    +------------------------+----------------------------------------------------------------------+
+    | **Beginner**           | :ref:`Index<beginner_docs>`                                          |
+    +------------------------+----------------------------------------------------------------------+
+    | **User**               | :ref:`Index<user_docs>`                                              |
+    +------------------------+----------------------------------------------------------------------+
+    | **Developer**          | :ref:`Index<developer_docs>`                                         |
+    +------------------------+----------------------------------------------------------------------+
+    | **Advanced**           | :ref:`Index<advanced_docs>`                                          |
+    +------------------------+----------------------------------------------------------------------+
+
+
 .. toctree::
    :hidden:
 

--- a/index_advanced.rst
+++ b/index_advanced.rst
@@ -1,0 +1,9 @@
+.. _advanced_docs:
+
+Contents for advanced
+==================
+
+.. toctree::
+   :maxdepth: 2
+   :extralabel: {"audience": ["advanced", "all"]}
+

--- a/index_advanced.rst
+++ b/index_advanced.rst
@@ -1,9 +1,57 @@
 .. _advanced_docs:
 
 Contents for advanced
-==================
+=====================
+
+Advanced can be intrested in build system, specifications, database concepts, 
+and details of protocols.
+
+..
+   Note that below there all the articles
+   but thanks to extralabel audience only that properly labelerd are visible
+..
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :extralabel: {"audience": ["advanced", "all"]}
 
+   getting-started/EPICS_Intro
+   getting-started/installation
+   getting-started/linux-packages.rst
+   getting-started/creating-ioc
+   getting-started/installation-windows
+
+   process-database/common-database-patterns
+   process-database/how-to-avoid-copying-arrays-with-waveformrecord
+   process-database/how-to-find-which-ioc-provides-a-pv
+   Application Developer's Guide (pdf, 3.16.2) <https://epics.anl.gov/base/R3-16/2-docs/AppDevGuide.pdf>
+   Application Developer's Guide (web version, preliminary) <appdevguide/AppDevGuide>
+   process-database/EPICS_Process_Database_Concepts.rst
+
+   software/epics-related-software
+
+   build-system/how-to-port-epics-to-a-new-os-architecture
+   build-system/cross-compile-epics-and-a-ioc-to-an-old-x86-linux.md
+   Getting Started with EPICS on RTEMS 4 <https://epics.anl.gov/base/RTEMS/tutorial/tutorial.html>
+   build-system/configuring-vxworks-6_x
+   build-system/vxworks6_tornado
+   build-system/specifications
+
+   pv-access/overview
+   PV Access specifications <https://github.com/epics-base/pvAccessCPP/wiki/protocol>
+   pv-access/Normative-Types-Specification
+   pv-access/OverviewOfpvData
+
+   access-security/specifications
+
+   internal/ca_protocol
+   internal/IOCInit
+
+   contributing/HowToWorkWithTheEpicsRepository
+   CONTRIBUTING
+
+   specs/specs
+   software/base
+
+   Training Material <https://epics-controls.org/resources-and-support/documents/training/>
+   community/how-to-run-an-epics-collaboration-meeting.rst

--- a/index_beginners.rst
+++ b/index_beginners.rst
@@ -1,0 +1,9 @@
+.. _beginner_docs:
+
+Contents for beginners
+==================
+
+.. toctree::
+   :maxdepth: 2
+   :extralabel: {"audience": ["beginners", "all"]}
+

--- a/index_beginners.rst
+++ b/index_beginners.rst
@@ -1,9 +1,57 @@
 .. _beginner_docs:
 
 Contents for beginners
-==================
+======================
+
+Articles intended for beginners concentrate on the installation 
+and understaing of basic topics of EPICS.
 
 .. toctree::
-   :maxdepth: 2
-   :extralabel: {"audience": ["beginners", "all"]}
+   :maxdepth: 1
+   :extralabel: {"audience": ["beginner", "all"]}
 
+..
+   Note that below there all the articles
+   but thanks to extralabel audience only that properly labelerd are visible
+..
+
+   getting-started/EPICS_Intro
+   getting-started/installation
+   getting-started/linux-packages.rst
+   getting-started/creating-ioc
+   getting-started/installation-windows
+
+   process-database/common-database-patterns
+   process-database/how-to-avoid-copying-arrays-with-waveformrecord
+   process-database/how-to-find-which-ioc-provides-a-pv
+   Application Developer's Guide (pdf, 3.16.2) <https://epics.anl.gov/base/R3-16/2-docs/AppDevGuide.pdf>
+   Application Developer's Guide (web version, preliminary) <appdevguide/AppDevGuide>
+   process-database/EPICS_Process_Database_Concepts.rst
+
+   software/epics-related-software
+
+   build-system/how-to-port-epics-to-a-new-os-architecture
+   build-system/cross-compile-epics-and-a-ioc-to-an-old-x86-linux.md
+   Getting Started with EPICS on RTEMS 4 <https://epics.anl.gov/base/RTEMS/tutorial/tutorial.html>
+   build-system/configuring-vxworks-6_x
+   build-system/vxworks6_tornado
+   build-system/specifications
+
+   pv-access/overview
+   PV Access specifications <https://github.com/epics-base/pvAccessCPP/wiki/protocol>
+   pv-access/Normative-Types-Specification
+   pv-access/OverviewOfpvData
+
+   access-security/specifications
+
+   internal/ca_protocol
+   internal/IOCInit
+
+   contributing/HowToWorkWithTheEpicsRepository
+   CONTRIBUTING
+
+   specs/specs
+   software/base
+
+   Training Material <https://epics-controls.org/resources-and-support/documents/training/>
+   community/how-to-run-an-epics-collaboration-meeting.rst

--- a/index_beginners.rst
+++ b/index_beginners.rst
@@ -6,14 +6,14 @@ Contents for beginners
 Articles intended for beginners concentrate on the installation 
 and understaing of basic topics of EPICS.
 
-.. toctree::
-   :maxdepth: 1
-   :extralabel: {"audience": ["beginner", "all"]}
-
 ..
    Note that below there all the articles
    but thanks to extralabel audience only that properly labelerd are visible
 ..
+
+.. toctree::
+   :maxdepth: 1
+   :extralabel: {"audience": ["beginner", "all"]}
 
    getting-started/EPICS_Intro
    getting-started/installation

--- a/index_developers.rst
+++ b/index_developers.rst
@@ -1,0 +1,8 @@
+.. _developer_docs:
+
+Contents for developer
+==================
+
+.. toctree::
+   :maxdepth: 2
+   :extralabel: {"audience": ["developers", "all"]}

--- a/index_developers.rst
+++ b/index_developers.rst
@@ -5,14 +5,14 @@ Contents for developer
 
 Articles for developers focus on the IOCs, usage of modules and extensions
 
-.. toctree::
-   :maxdepth: 1
-   :extralabel: {"audience": ["developer", "all"]}
-
 ..
    Note that below there all the articles
    but thanks to extralabel audience only that properly labelerd are visible
 ..
+
+.. toctree::
+   :maxdepth: 1
+   :extralabel: {"audience": ["developer", "all"]}
 
    getting-started/EPICS_Intro
    getting-started/installation

--- a/index_developers.rst
+++ b/index_developers.rst
@@ -1,8 +1,56 @@
 .. _developer_docs:
 
 Contents for developer
-==================
+======================
+
+Articles for developers focus on the IOCs, usage of modules and extensions
 
 .. toctree::
-   :maxdepth: 2
-   :extralabel: {"audience": ["developers", "all"]}
+   :maxdepth: 1
+   :extralabel: {"audience": ["developer", "all"]}
+
+..
+   Note that below there all the articles
+   but thanks to extralabel audience only that properly labelerd are visible
+..
+
+   getting-started/EPICS_Intro
+   getting-started/installation
+   getting-started/linux-packages.rst
+   getting-started/creating-ioc
+   getting-started/installation-windows
+
+   process-database/common-database-patterns
+   process-database/how-to-avoid-copying-arrays-with-waveformrecord
+   process-database/how-to-find-which-ioc-provides-a-pv
+   Application Developer's Guide (pdf, 3.16.2) <https://epics.anl.gov/base/R3-16/2-docs/AppDevGuide.pdf>
+   Application Developer's Guide (web version, preliminary) <appdevguide/AppDevGuide>
+   process-database/EPICS_Process_Database_Concepts.rst
+
+   software/epics-related-software
+
+   build-system/how-to-port-epics-to-a-new-os-architecture
+   build-system/cross-compile-epics-and-a-ioc-to-an-old-x86-linux.md
+   Getting Started with EPICS on RTEMS 4 <https://epics.anl.gov/base/RTEMS/tutorial/tutorial.html>
+   build-system/configuring-vxworks-6_x
+   build-system/vxworks6_tornado
+   build-system/specifications
+
+   pv-access/overview
+   PV Access specifications <https://github.com/epics-base/pvAccessCPP/wiki/protocol>
+   pv-access/Normative-Types-Specification
+   pv-access/OverviewOfpvData
+
+   access-security/specifications
+
+   internal/ca_protocol
+   internal/IOCInit
+
+   contributing/HowToWorkWithTheEpicsRepository
+   CONTRIBUTING
+
+   specs/specs
+   software/base
+
+   Training Material <https://epics-controls.org/resources-and-support/documents/training/>
+   community/how-to-run-an-epics-collaboration-meeting.rst

--- a/index_users.rst
+++ b/index_users.rst
@@ -1,0 +1,9 @@
+.. _user_docs:
+
+Contents for users
+==================
+
+.. toctree::
+   :maxdepth: 2
+   :extralabel: {"audience": ["users", "all"]}
+

--- a/index_users.rst
+++ b/index_users.rst
@@ -3,7 +3,55 @@
 Contents for users
 ==================
 
-.. toctree::
-   :maxdepth: 2
-   :extralabel: {"audience": ["users", "all"]}
+Users can get familarized with topics like creating IOC, 
+accessing PVs and using EPICS on specific architecture.
 
+.. toctree::
+   :maxdepth: 1
+   :extralabel: {"audience": ["user", "all"]}
+
+..
+   Note that below I put all the articles
+   but thanks to extralabel audience only that with all or user are visible
+..
+
+   getting-started/EPICS_Intro
+   getting-started/installation
+   getting-started/linux-packages.rst
+   getting-started/creating-ioc
+   getting-started/installation-windows
+
+   process-database/common-database-patterns
+   process-database/how-to-avoid-copying-arrays-with-waveformrecord
+   process-database/how-to-find-which-ioc-provides-a-pv
+   Application Developer's Guide (pdf, 3.16.2) <https://epics.anl.gov/base/R3-16/2-docs/AppDevGuide.pdf>
+   Application Developer's Guide (web version, preliminary) <appdevguide/AppDevGuide>
+   process-database/EPICS_Process_Database_Concepts.rst
+
+   software/epics-related-software
+
+   build-system/how-to-port-epics-to-a-new-os-architecture
+   build-system/cross-compile-epics-and-a-ioc-to-an-old-x86-linux.md
+   Getting Started with EPICS on RTEMS 4 <https://epics.anl.gov/base/RTEMS/tutorial/tutorial.html>
+   build-system/configuring-vxworks-6_x
+   build-system/vxworks6_tornado
+   build-system/specifications
+
+   pv-access/overview
+   PV Access specifications <https://github.com/epics-base/pvAccessCPP/wiki/protocol>
+   pv-access/Normative-Types-Specification
+   pv-access/OverviewOfpvData
+
+   access-security/specifications
+
+   internal/ca_protocol
+   internal/IOCInit
+
+   contributing/HowToWorkWithTheEpicsRepository
+   CONTRIBUTING
+
+   specs/specs
+   software/base
+
+   Training Material <https://epics-controls.org/resources-and-support/documents/training/>
+   community/how-to-run-an-epics-collaboration-meeting.rst

--- a/index_users.rst
+++ b/index_users.rst
@@ -6,14 +6,14 @@ Contents for users
 Users can get familarized with topics like creating IOC, 
 accessing PVs and using EPICS on specific architecture.
 
-.. toctree::
-   :maxdepth: 1
-   :extralabel: {"audience": ["user", "all"]}
-
 ..
    Note that below I put all the articles
    but thanks to extralabel audience only that with all or user are visible
 ..
+
+.. toctree::
+   :maxdepth: 1
+   :extralabel: {"audience": ["user", "all"]}
 
    getting-started/EPICS_Intro
    getting-started/installation

--- a/internal/IOCInit.rst
+++ b/internal/IOCInit.rst
@@ -1,6 +1,8 @@
 IOC Initialization
 ------------------
 
+:audience:`advanced`
+
 .. contents:: Table of Contents
  :depth: 3
 

--- a/internal/ca_protocol.rst
+++ b/internal/ca_protocol.rst
@@ -1,5 +1,6 @@
 Channel Access Protocol Specification
 =====================================
+:audience:`advanced`
 
 Table of Contents
 

--- a/process-database/EPICS_Process_Database_Concepts.rst
+++ b/process-database/EPICS_Process_Database_Concepts.rst
@@ -1,5 +1,6 @@
 EPICS Process Database Concepts
 ===============================
+:audience:`beginner, user, developer`
 
 .. contents:: Table of Contents
  :depth: 3

--- a/process-database/common-database-patterns.rst
+++ b/process-database/common-database-patterns.rst
@@ -1,6 +1,8 @@
 Common Database patterns
 ========================
 
+:audience:`developer`
+
 Pull Alarm Status w/o Data
 --------------------------
 This is useful to bring alarm status in without affecting the value stored in a record. 

--- a/process-database/how-to-avoid-copying-arrays-with-waveformrecord.rst
+++ b/process-database/how-to-avoid-copying-arrays-with-waveformrecord.rst
@@ -1,6 +1,9 @@
 How to Avoid Copying Arrays with waveformRecord
 ===============================================
 
+:audience:`developer`
+
+
 This page describes how to use the array field memory management feature that was introduced in EPICS 3.15.1.
 This allows array data to be moved into and out of the value (aka BPTR) field of the waveform, aai, and aao types.
 

--- a/process-database/how-to-find-which-ioc-provides-a-pv.rst
+++ b/process-database/how-to-find-which-ioc-provides-a-pv.rst
@@ -1,6 +1,7 @@
 How to find which IOC provides a PV
 ===================================
 
+:audience:`user`
 This process is for IOCs running on Linux servers.
 
 Find Host and TCP port

--- a/pv-access/Normative-Types-Specification.rst
+++ b/pv-access/Normative-Types-Specification.rst
@@ -1,6 +1,9 @@
 EPICS V4 Normative Types
 ========================
 
+:audience:`advanced`
+
+
 EPICS V4 Normative Types, Editors Draft, 16-Mar-2015
 ----------------------------------------------------
 

--- a/pv-access/OverviewOfpvData.rst
+++ b/pv-access/OverviewOfpvData.rst
@@ -1,6 +1,9 @@
 EPICS 7, pvAccess and pvData
 ============================
 
+:audience:`developer, advanced`
+
+
 pvAccess, pvData and other related modules have been introduced into EPICS
 to add support for structured data. Let us look into the
 reasons, and also at some use cases for the capabilities to handle

--- a/software/epics-related-software.md
+++ b/software/epics-related-software.md
@@ -1,4 +1,8 @@
 # EPICS Related Software
+
+{audience}`user, developer, all`
+
+
 This page attempts to list all EPICS-related source code and documentation outside of [EPICS Base](https://git.launchpad.net/epics-base). If you find a link is incorrect or missing, please [submit an issue](https://github.com/epics-docs/epics-docs/issues/new/choose) or pull-request with a fix on the [epics-docs](https://github.com/epics-docs/epics-docs) repository. When submitting a pull-request, be sure to be familiar with our [documentation contribution guide](../CONTRIBUTING.md).
 
 ## IOC Support Modules


### PR DESCRIPTION
Idea: make possible to mark pages with extra labels for example to idicate the audience. <br/>
For now in conf.py I specified audience to 'advanced', 'developers', 'users', 'beginners', 'all'.