### PR TITLE
Integrate base Read the Docs project

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -52,6 +52,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.*', 'README.md']
 
 # Intersphinx links to subprojects
 intersphinx_mapping = {
+    "epics-base": ("https://docs.epics-controls.org/projects/base/en/latest/", None),
     'how-tos': ('https://docs.epics-controls.org/projects/how-tos/en/latest', None),
     'pvxs' : ('https://mdavidsaver.github.io/pvxs', None),
     'phoebus' : ('https://control-system-studio.readthedocs.io/en/latest/', None),
@@ -59,11 +60,12 @@ intersphinx_mapping = {
     'asyn' : ('http://epics-modules.github.io/asyn/', None),
     'channelfinder' : ('https://channelfinder.readthedocs.io/en/latest/', None),
 }
+intersphinx_disabled_reftypes = ["*"]
 hoverxref_intersphinx = [
-    'how-tos',
+    'epics-base',
 ]
 hoverxref_intersphinx_types = {
-    'how-tos': 'modal',
+    'epics-base': 'modal',
 }
 
 numfig = True

--- a/index.rst
+++ b/index.rst
@@ -86,6 +86,7 @@ You may also directly use related links to see documents which match you the mos
    getting-started/installation-rtems
    getting-started/creating-ioc
    getting-started/os-specifics
+   EPICS 7.0 Release Notes <https://docs.epics-controls.org/projects/base/en/latest/RELEASE_NOTES.html>
 
 
 .. toctree::
@@ -106,6 +107,7 @@ You may also directly use related links to see documents which match you the mos
    :maxdepth: 1
    :caption: Use Cases and Design Patterns
 
+   IOC Component Reference <https://docs.epics-controls.org/projects/base/en/latest/ComponentReference.html>
    process-database/common-database-patterns
    Database Examples (external link) <https://github.com/epics-docs/database-examples>
    process-database/how-to-avoid-copying-arrays-with-waveformrecord
@@ -116,7 +118,7 @@ You may also directly use related links to see documents which match you the mos
 .. toctree::
    :maxdepth: 1
    :caption: EPICS Related Software
-   
+
    software/epics-related-software
 
 .. toctree::
@@ -131,7 +133,7 @@ You may also directly use related links to see documents which match you the mos
 .. toctree::
    :maxdepth: 1
    :caption: System administration
-   
+
    sys-admin/configure-ca
    sys-admin/how-to-find-which-ioc-provides-a-pv
    sys-admin/channel-access-reach-multiple-soft-iocs-linux
@@ -145,6 +147,8 @@ You may also directly use related links to see documents which match you the mos
 
    internal/ca_protocol
    internal/IOCInit
+   Common Library C/C++ APIs <https://docs.epics-controls.org/projects/base/en/latest/libcom-api.html>
+   IOC Database C/C++ APIs <https://docs.epics-controls.org/projects/base/en/latest/database-api.html>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Depends on epics-base/epics-base#420

This integrates the Read the Docs project from epics-base, and add links to it, including:

- Release notes
- Record reference
- C/C++ API reference

Looks like this: https://epics--47.org.readthedocs.build/en/47/