### PR TITLE
editorconfig: trim trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ root = true
 # Not 'end_of_line = lf' because Git is configured to convert EOL
 # in .gitattributes
 insert_final_newline = true
+# Markdown can use trailing whitespaces for forcing line breaks,
+# but we can just use paragraphs instead.
+trim_trailing_whitespace = true


### PR DESCRIPTION
This asks editors supporting the editorconfig standard to automatically trim trailing whitespace on save.