### PR TITLE
fix tag

### DIFF
--- a/build-system/how-to-port-epics-to-a-new-os-architecture.rst
+++ b/build-system/how-to-port-epics-to-a-new-os-architecture.rst
@@ -1,8 +1,8 @@
 How To Port EPICS to a new OS/Architecture
 ==========================================
 
-```{tags} user
-```
+.. tags:: user
+
 
 This isn’t a detailed list of tasks, but is intended to show the main stages needed to add a new build architecture to EPICS. 
 If you make use of this and find there are hints you’d like to suggest, or steps missing please add them.


### PR DESCRIPTION
tag for a `.md` file is wrongly used for a `.rst` file in `How To Port EPICS to a new OS/Architecture`