### PR TITLE
add a remark that the old AppDevGuide is a pdf

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -100,7 +100,7 @@ You may also directly use related links to see documents which match you the mos
    IOC Initialization <appdevguide/IOCInit>
    appdevguide/AccessSecurity
    IOC Test Facilities <appdevguide/IOCTestFacilities>
-   Application Developer's Guide (historical, for 3.16.2) <https://epics.anl.gov/base/R3-16/2-docs/AppDevGuide.pdf>
+   Application Developer's Guide (historical pdf, for 3.16.2) <https://epics.anl.gov/base/R3-16/2-docs/AppDevGuide.pdf>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Minor: add a remark that the old AppDevGuide (3.16) is a pdf.