### PR TITLE
Update installation-linux.rst

### DIFF
--- a/getting-started/installation-linux.rst
+++ b/getting-started/installation-linux.rst
@@ -40,7 +40,7 @@ by adding the following to either one of those files:
 
 ::
 
-    export EPICS_BASE=${HOME}/EPICS/epics-base
+    export EPICS_BASE=${HOME}/EPICS/base-7.0.8.1
     export EPICS_HOST_ARCH=$(${EPICS_BASE}/startup/EpicsHostArch)
     export PATH=${EPICS_BASE}/bin/${EPICS_HOST_ARCH}:${PATH}
 


### PR DESCRIPTION
It looks like export EPICS_BASE=${HOME}/EPICS/epics-base is the wrong path. It should be export EPICS_BASE=${HOME}/EPICS/base-7.0.8.1.