### PR TITLE
Fix pvAccess specification warnings

### DIFF
--- a/pv-access/Protocol-Encoding.md
+++ b/pv-access/Protocol-Encoding.md
@@ -1,27 +1,7 @@
 # Data Encoding
 
-[Back to main](protocol)
-
-1.  [Sizes](#sizes)
-2.  [User Data](#user-data)
-    - [Basic Types](#basic-types)
-    - [Arrays](#arrays)
-    - [Strings](#strings)
-    - [Bounded Strings](#bounded-strings)
-    - [Structures](#structures)
-    - [Arrays of Structures](#variable-size-structure-arrays)
-    - [Unions](#unions)
-    - [Variant Unions](#variant-unions)
-    - [Encoding Example](#encoding-example)
-3.  [Meta Data](#meta-data)
-    - [BitSets](#bitsets)
-        - [Partial Structure Serialization](#partial-structure-serialization)
-    - [Status](#status)
-    - [Introspection Data](#introspection-data)
-        - [Example \#1](#example-1)
-        - [Example \#2](#example-2)
-
-
+```{contents}
+```
 
 Encoding does not align primitive types on word boundaries.
 

--- a/pv-access/Protocol-Encoding.md
+++ b/pv-access/Protocol-Encoding.md
@@ -1,8 +1,6 @@
-# pvAccess Protocol Specification
+# Data Encoding
 
 [Back to main](protocol)
-
-## Data Encoding
 
 1.  [Sizes](#sizes)
 2.  [User Data](#user-data)
@@ -37,7 +35,7 @@ require a specific byte order for connection-less protocols (UDP/IP).
 Deviation: Current peers ignore the header endian bit for messages received over TCP.
 The `SET_ENDIANESS` control message is used instead.  Similarly w/ protocol version.
 
-### Sizes
+## Sizes
 
 Many of the types involved in the data encoding, as well as several
 protocol message components, have an associated size (or "count"). Size
@@ -56,9 +54,9 @@ values MUST always be a non-negative integer and encoded as follows:
     followed by a positive signed 64-bit integer indicating the number
     of elements. This implies a maximum size of 2^63-1.
 
-### User Data
+## User Data
 
-#### Basic Types
+### Basic Types
 
 The basic types MUST be encoded as shown in the Table 1. Signed integer
 types (byte, short, int, long) MUST be represented as two’s complement
@@ -85,28 +83,28 @@ Encoding for basic types.
 value of true is represented by any special non-zero number, nor that
 the same sender consistently uses the same number.*
 
-#### Arrays
+### Arrays
 
-##### Variable-size Arrays
+#### Variable-size Arrays
 
 Variable-size arrays MUST be encoded as a size representing the number
 of elements in the array, followed by the elements encoded as specified
 for their type (as specified in these sections).
 
-##### Bounded-size Arrays
+#### Bounded-size Arrays
 
 Bounded-size arrays MUST be encoded as a size representing the number of
 elements in the array, followed by the elements encoded as specified for
 their type (as specified in these sections). The size MUST be less then
 or equal to the array's declared bound.
 
-##### Fixed-size Arrays
+#### Fixed-size Arrays
 
 Fixed-size arrays MUST be encoded as elements encoded as specified for
 their type (as specified in these sections). The number of elements
 encoded MUST equal to the array's fixed size.
 
-#### Strings
+### Strings
 
 Strings are encoded as arrays of bytes. The actual content (the bytes in
 the array) MUST be a valid [UTF-8](http://tools.ietf.org/html/rfc3629)
@@ -122,18 +120,18 @@ Implementations that internally use a zero byte or a zero character to
 indicate end-of-string SHOULD NOT include a terminating zero byte in the
 pvAccess string encoding. 'null' strings are not supported.
 
-#### Bounded Strings
+### Bounded Strings
 
 Same as strings, just that size MUST be less than or equal to the
 string's bound.
 
-#### Structures
+### Structures
 
 Structures MUST be encoded by appending the data of all comprising
 fields in the order in which the fields have been defined. A structure
 can contain a structure and an union (see below) for its field.
 
-#### Variable-size Structure Arrays
+### Variable-size Structure Arrays
 
 An array of structures is encoded as a size representing the number
 of elements in the array. For each array element, the encoding then
@@ -151,7 +149,7 @@ would be encoded as
 
     03 01 11 11 22 22 00 01 33 33 44 44
 
-#### Unions
+### Unions
 
 Unions MUST be encoded as a selector value (encoded as a size), followed
 by the selected union member data. The selector chooses one member of a
@@ -159,13 +157,13 @@ union as specified in the union introspection data, so must be a value
 in the range 0..N-1 where N is the number of union members. A union can
 contain a structure and a union for its field.
 
-#### Variant Unions
+### Variant Unions
 
 Variant Unions are open ended union type, also known as *any* type.
 Variant Unions MUST be encoded as a introspection data (*Field*)
 description of the encoded value, followed by the encoded value itself.
 
-#### Encoding Example
+### Encoding Example
 
 Given the following structure:
 
@@ -197,9 +195,9 @@ big-endian byte order, *valueUnion* selector with value 1 is selected):
     69 6E 73 69  64 65 20 76  61 72 69 61  6E 74 20 75  insi de v aria nt u 
     6E 69 6F 6E  2E                                     nion .
 
-### Meta Data
+## Meta Data
 
-#### BitSets
+### BitSets
 
 BitSet is a data type that represents a finite sequence of bits.
 
@@ -266,7 +264,7 @@ Examples of BitSet serialization:
     Hexdump [{8, 17, 24, 25, 34, 40, 42, 49, 50, 56, 57, 58, 67, 72, 75, 81, 83}] size = 12
     0B 00 01 02  03 04 05 06  07 08 09 0A               .... .... .... 
 
-##### Partial Structure Serialization
+#### Partial Structure Serialization
 
 Each structure can (depending on message definition) have a BitSet
 instance defining what subset of that structure's fields have been
@@ -304,7 +302,7 @@ The structure above requires a BitSet that contains 9 bits.
 If the bit corresponding to a structure node is set, then all the fields
 of that node MUST be serialized.
 
-#### Status
+### Status
 
 pvAccess defines a structure to inform endpoints about completion
 status. It is nominally defined as:
@@ -353,7 +351,7 @@ Examples of Status serialization:
     61 74 69 6F  6E 45 78 61  6D 70 6C 65  73 2E 6A 61  atio nExa mple s.ja 
     76 61 3A 31  32 36 29 0A                            va:1 26). 
 
-#### Introspection Data
+### Introspection Data
 
 Introspection data describes the type of a user data item. It is not
 itself user data, but rather meta data. Introspection data appears in
@@ -480,7 +478,7 @@ structure/union defining an array element type.
 :::
 
 
-##### Example \#1
+#### Example \#1
 
 Given the following structure, as may be expressed by a pvData
 Structure:
@@ -499,7 +497,7 @@ pvAccess as the following:
     63 68 23 0B  6E 61 6E 6F  53 65 63 6F  6E 64 73 22  ch#. nano Seco nds" 
     07 75 73 65  72 54 61 67  22                        .use rTag "
 
-##### Example \#2
+#### Example \#2
 
 Given the following structure, as may be expressed by a pvData
 Structure:

--- a/pv-access/Protocol-Encoding.md
+++ b/pv-access/Protocol-Encoding.md
@@ -43,6 +43,9 @@ types (byte, short, int, long) MUST be represented as two’s complement
 numbers. Floating point types (float, double) MUST use the 
 [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754) standard formats.
 
+:::{table} Encoding for basic types
+:align: center
+
 |    Type | Encoding                                                          |
 | ------: | ----------------------------------------------------------------- |
 | boolean | A single byte with value non-zero value for true, zero for false. |
@@ -56,8 +59,7 @@ numbers. Floating point types (float, double) MUST use the
 |   ulong | Unsigned 64-bit integer.                                          |
 |   float | 32-bit float (IEEE-754 single-precision float).                   |
 |  double | 64-bit float (IEEE-754 double-precision float).                   |
-
-Encoding for basic types.
+:::
 
 *Note on boolean encoding: a receiver MUST NOT assume that a boolean
 value of true is represented by any special non-zero number, nor that
@@ -147,7 +149,7 @@ description of the encoded value, followed by the encoded value itself.
 
 Given the following structure:
 
-    structure 
+    structure
         byte[] value [1,2,3]
         byte<16> boundedSizeArray [4,5,6,7,8]
         byte[4] fixedSizeArray [9,10,11,12]
@@ -361,6 +363,7 @@ introspection data instance. The introspection registry size MUST be
 negotiated when each connection is established.
 
 :::{table} Encoding of Introspection Data (called Field for future reference).
+:align: center
 
 | Field Encoding             | Name                     | Description |
 | --------------             | ----                     | ----------- |
@@ -380,6 +383,7 @@ The remaining 3 lower bits are type dependent and used for size
 encoding, e.g. to select a 'short' or 'long' integer.
 
 :::{table} Type Encoding
+:align: center
 
 | Bit | Value | Description |
 | --- | ----- | ----------- |
@@ -398,6 +402,7 @@ encoding, e.g. to select a 'short' or 'long' integer.
 :::
 
 :::{table} Integer Type Size Encoding
+:align: center
 
 | Bit | Value | Type Name |
 | --- | ----- | --------- |
@@ -410,6 +415,7 @@ encoding, e.g. to select a 'short' or 'long' integer.
 :::
 
 :::{table} Floating-Point Size Encoding (type = '0b010')
+:align: center
 
 | Bit | Value | Type Name | IEEE 754-2008 Name |
 | --- | ----- | --------- | ------------------ |
@@ -422,6 +428,7 @@ encoding, e.g. to select a 'short' or 'long' integer.
 :::
 
 :::{table} Complex Type Encoding (type = '0b100')
+:align: center
 
 | Bit | Value | Type Name |
 | --- | ----- | --------- |
@@ -441,6 +448,7 @@ pairs. Arrays of structures/unions REQUIRE an introspection data of a
 structure/union defining an array element type.
 
 :::{table} FieldDesc Encoding
+:align: center
 
 | FieldDesc Encoding | Description |
 | ------------------ | ----------- |
@@ -448,7 +456,7 @@ structure/union defining an array element type.
 | 0bxxx01xxx |  Variable-size array of scalars |
 | 0bxxx10xxx + bound |  Bounded-size array of scalars  |
 | 0bxxx11xxx + fixed size (encoded as size) |  Fixed-size array of scalars |
-| 0b10000000 + identification string + (field name, FieldDesc)[] |  Structure | 
+| 0b10000000 + identification string + (field name, FieldDesc)[] |  Structure |
 | 0b10001000 + structure FieldDesc | Array of structures. |
 | 0b10000001 + identification string + (field name, FieldDesc)[] | Union |
 | 0b10001001 + union FieldDesc | Array of unions |

--- a/pv-access/Protocol-Messages.md
+++ b/pv-access/Protocol-Messages.md
@@ -22,13 +22,15 @@ which it is conformant, using the version URLs above.
 Each protocol message has a fixed 8-byte header that MUST be encoded as
 if it were expressed by the following structure:
 
-    struct pvAccessHeader {
-        byte magic;
-        byte version;
-        byte flags;
-        byte messageCommand;
-        int payloadSize;
-    };
+```c
+struct pvAccessHeader {
+    byte magic;
+    byte version;
+    byte flags;
+    byte messageCommand;
+    int payloadSize;
+};
+```
 
 The semantics of these message header components are given in the
 following table.
@@ -113,17 +115,19 @@ Beacons are be used to announce the appearance and continued presence of servers
 Clients may use Beacons to detect when new servers appear,
 and may use this information to more quickly retry unanswered CMD_SEARCH messages.
 
-    struct beaconMessage {
-        byte[12] guid;
-        byte flags;
-        byte beaconSequenceId;
-        short changeCount;
-        byte[16] serverAddress;
-        short serverPort;
-        string protocol;
-        FieldDesc serverStatusIF;
-        [if serverStatusIF != NULL_TYPE_CODE] PVField serverStatus;
-    };
+```c
+struct beaconMessage {
+    byte[12] guid;
+    byte flags;
+    byte beaconSequenceId;
+    short changeCount;
+    byte[16] serverAddress;
+    short serverPort;
+    string protocol;
+    FieldDesc serverStatusIF;
+    [if serverStatusIF != NULL_TYPE_CODE] PVField serverStatus;
+};
+```
 
 :::{table} Beacon Message Members
 :align: center
@@ -186,24 +190,25 @@ it has received a connection validation message from the server.
 The connection validation request and connection validation response
 messages are defined as follows:
 
-    // Server to Client
-    struct connectionValidationRequest {
-        int serverReceiveBufferSize;
-        short serverIntrospectionRegistryMaxSize;
-        string[] authNZ;                        // list of supported authNZ;
-    };
+```c
+// Server to Client
+struct connectionValidationRequest {
+    int serverReceiveBufferSize;
+    short serverIntrospectionRegistryMaxSize;
+    string[] authNZ;                        // list of supported authNZ;
+};
 
-    // Client to Server
-    struct connectionValidationResponse {
-        int clientReceiveBufferSize;
-        short clientIntrospectionRegistryMaxSize;
-        short connectionQos;
-        string authNZ;                          // selected authNZ plugin;
-        // Optional, content depends on authNZ
-        FieldDesc dataIF;  
-        PVField data;
-    };
-
+// Client to Server
+struct connectionValidationResponse {
+    int clientReceiveBufferSize;
+    short clientIntrospectionRegistryMaxSize;
+    short connectionQos;
+    string authNZ;                          // selected authNZ plugin;
+    // Optional, content depends on authNZ
+    FieldDesc dataIF;
+    PVField data;
+};
+```
 
 In the connectionValidationRequest, the server lists the support authentication methods.
 Currently supported are "anonymous", "ca", "x509".
@@ -261,13 +266,15 @@ be whether a streaming mode algorithm should be specified.
 An Echo diagnostic message is usually sent to check if TCP/IP connection
 is still valid.
 
-    struct echoRequest {
-        byte[] somePayload;
-    };
-    
-    struct echoResponse {
-        byte[] samePayloadAsInRequest;
-    };
+```c
+struct echoRequest {
+    byte[] somePayload;
+};
+
+struct echoResponse {
+    byte[] samePayloadAsInRequest;
+};
+```
 
 :::{table} Echo request message members
 :align: center
@@ -294,20 +301,20 @@ A channel "search request" message SHOULD be sent over UDP/IP, however
 UDP congestion control SHOULD be implemented in this case. A server MUST
 accept this message also over TCP/IP.
 
-```         
+```c
 struct searchRequest {
     int searchSequenceID;
     byte flags; // 0-bit for replyRequired, 7-th bit for "sent as unicast" (1)/"sent as broadcast/multicast" (0)
 
     byte[3] reserved;
-    
+
     // if not provided (or zero), the same transport is used for responses
     // needs to be set when local broadcast (multicast on loop interface) is done
     byte[16] responseAddress; // e.g. IPv6 address in case of IP based transport, UDP
     short responsePort;       // e.g. socket port in case of IP based transport
-    
+
     string[] protocols;
-    
+
     struct {
         int searchInstanceID;
         string channelName;
@@ -353,15 +360,17 @@ TCP connection.
 A search response message MUST be sent as the response to a specific
 search request (0x03) message.
 
-    struct searchResponse {
-        byte[12] guid;          
-        int searchSequenceID;
-        byte[16] serverAddress; // e.g. IPv6 address in case of IP based transport 
-        short serverPort;       // e.g. socket port in case of IP based transport
-        string protocol;
-        boolean found;
-        int[] searchInstanceIDs;
-    };
+```c
+struct searchResponse {
+    byte[12] guid;          
+    int searchSequenceID;
+    byte[16] serverAddress; // e.g. IPv6 address in case of IP based transport 
+    short serverPort;       // e.g. socket port in case of IP based transport
+    string protocol;
+    boolean found;
+    int[] searchInstanceIDs;
+};
+```
 
 :::{table} Search response message members
 :align: center
@@ -393,29 +402,33 @@ the client should use that same TCP connection for further communication.
 
 ### CMD_AUTHNZ (0x05)
 
-    struct authNZRequest {
-        FieldDesc dataIF;
-        [if dataIF != NULL_TYPE_CODE] PVField data;
-    };
-    
-    struct authNZResponse {
-        FieldDesc dataIF;
-        [if dataIF != NULL_TYPE_CODE] PVField data;
-    };
+```c
+struct authNZRequest {
+    FieldDesc dataIF;
+    [if dataIF != NULL_TYPE_CODE] PVField data;
+};
+
+struct authNZResponse {
+    FieldDesc dataIF;
+    [if dataIF != NULL_TYPE_CODE] PVField data;
+};
+```
 
 ### CMD_ACL_CHANGE (0x06)
 
 
 This is a placeholder message code not used by existing peers.
-    
-    // TODO new message code (from server) 0x06
-    struct aclChange {
-        int clientChannelID;
-        struct {
-            int requestID;  // invalid ID is 0 (means for channel)
-            BitSet[] rights;   // get has only one bit-set (readRights), put-get has 2 (read and write), channel has one (allowed/dissallowed request)
-        } changes[];
-    };
+
+```c
+// TODO new message code (from server) 0x06
+struct aclChange {
+    int clientChannelID;
+    struct {
+        int requestID;  // invalid ID is 0 (means for channel)
+        BitSet[] rights;   // get has only one bit-set (readRights), put-get has 2 (read and write), channel has one (allowed/dissallowed request)
+    } changes[];
+};
+```
 
 ### CMD_CREATE_CHANNEL (0x07)
 
@@ -424,20 +437,22 @@ hosted "process variable."
 
 Each channel instance MUST be bound only to one connection.
 
-    struct createChannelRequest {
-        short count;
-        struct {
-            int clientChannelID;
-            string channelName;
-        } channels[];
-    };
-    
-    struct createChannelResponse {
+```c
+struct createChannelRequest {
+    short count;
+    struct {
         int clientChannelID;
-        int serverChannelID;
-        Status status;		
-        // [if status.type == OK | WARNING] short accessRights; // never used
-    };
+        string channelName;
+    } channels[];
+};
+
+struct createChannelResponse {
+    int clientChannelID;
+    int serverChannelID;
+    Status status;
+    // [if status.type == OK | WARNING] short accessRights; // never used
+};
+```
 
 :::{table} Create channel request message members
 :align: center
@@ -482,15 +497,17 @@ A server may also send this message to the client when the channel is no longer
 available. Examples include a PVA gateway that sends this message from its server
 side when it lost a channel on its client side.
 
-    struct destroyChannelRequest {
-        int serverChannelID;
-        int clientChannelID;
-    };
-    
-    struct destroyChannelResponse {
-        int serverChannelID;
-        int clientChannelID;
-    };
+```c
+struct destroyChannelRequest {
+    int serverChannelID;
+    int clientChannelID;
+};
+
+struct destroyChannelResponse {
+    int serverChannelID;
+    int clientChannelID;
+};
+```
 
 :::{table} Destroy channel request
 :align: center
@@ -526,30 +543,33 @@ messages for the channel.
 
 Sent from Client to Server to indicate the completion of an Authentication handshake.
 
-    struct connectionValidated {
-        Status status;
-    };
-    
+```c
+struct connectionValidated {
+    Status status;
+};
+```
 
 ### CMD_GET (0x0A)
 
 A "channel get" set of messages are used to retrieve (get) data from the
 channel.
 
-    struct channelGetRequestInit {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x08 for INIT;
-        FieldDesc pvRequestIF;
-        PVField pvRequest;
-    };
-    
-    struct channelGetResponseInit {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] FieldDesc pvStructureIF;
-    };
+```c
+struct channelGetRequestInit {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x08 for INIT;
+    FieldDesc pvRequestIF;
+    PVField pvRequest;
+};
+
+struct channelGetResponseInit {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] FieldDesc pvStructureIF;
+};
+```
 
 :::{table} Channel get init request
 :align: center
@@ -577,19 +597,21 @@ channel.
 After a get request is successfully initialized, the client can issue
 actual get request(s).
 
-    struct channelGetRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x00 or 0x40 for GET; additional 0x10 mask for DESTROY;
-    };
-    
-    struct channelGetResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] BitSet changedBitSet;
-        [if status.type == OK | WARNING] PVField pvStructureData;
-    };
+```c
+struct channelGetRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x00 or 0x40 for GET; additional 0x10 mask for DESTROY;
+};
+
+struct channelGetResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] BitSet changedBitSet;
+    [if status.type == OK | WARNING] PVField pvStructureData;
+};
+```
 
 :::{table} Channel get request
 :align: center
@@ -628,20 +650,22 @@ receives the response.
 A "channel put" set of messages are used to set (put) data to the
 channel.
 
-    struct channelPutRequestInit {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x08;
-        FieldDesc pvRequestIF;
-        PVField pvRequest;
-    };
-    
-    struct channelPutResponseInit {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] FieldDesc pvPutStructureIF;
-    };
+```c
+struct channelPutRequestInit {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x08;
+    FieldDesc pvRequestIF;
+    PVField pvRequest;
+};
+
+struct channelPutResponseInit {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] FieldDesc pvPutStructureIF;
+};
+```
 
 :::{table} Channel put init request
 :align: center
@@ -669,19 +693,21 @@ channel.
 After a put request is successfully initialized, the client can issue
 actual put request(s) on the channel.
 
-    struct channelPutRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x00 for PUT; 0x10 mask for DESTROY;
-        BitSet toPutBitSet;
-        PVField pvPutStructureData;
-    };
-    
-    struct channelPutResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-    };
+```c
+struct channelPutRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x00 for PUT; 0x10 mask for DESTROY;
+    BitSet toPutBitSet;
+    PVField pvPutStructureData;
+};
+
+struct channelPutResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+};
+```
 
 :::{table} Channel put request
 :align: center
@@ -709,20 +735,22 @@ A "get-put" request retrieves the remote put structure. This MAY be used
 by user applications to show data that was set the last time by the
 application.
 
-    struct channelGetPutRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x40;
-    };
-    
-    struct channelGetPutResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING]
-            BitSet returnedDataBitSet;
-            PVField pvStructureData;
-    };
+```c
+struct channelGetPutRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x40;
+};
+
+struct channelGetPutResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING]
+        BitSet returnedDataBitSet;
+        PVField pvStructureData;
+};
+```
 
 :::{table} Channel get put request
 :align: center
@@ -753,21 +781,23 @@ channel and then immediately retrieve data from the channel. Channels
 are usually "processed" or "updated" by their host between put and get,
 so that the get reflects changes in the process variable's state.
 
-    struct channelPutGetRequestInit {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x08;
-        FieldDesc pvRequestIF;
-        PVField pvRequest;
-    };
-    
-    struct channelPutGetResponseInit {
-        int requestID;
-        byte subcommand; 
-        Status status;
-        [if status.type == OK | WARNING] FieldDesc pvPutStructureIF;
-        [if status.type == OK | WARNING] FieldDesc pvGetStructureIF;
-    };
+```c
+struct channelPutGetRequestInit {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x08;
+    FieldDesc pvRequestIF;
+    PVField pvRequest;
+};
+
+struct channelPutGetResponseInit {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] FieldDesc pvPutStructureIF;
+    [if status.type == OK | WARNING] FieldDesc pvGetStructureIF;
+};
+```
 
 :::{table} Channel put-get init request
 :align: center
@@ -796,20 +826,22 @@ so that the get reflects changes in the process variable's state.
 After a put-get request is successfully initialized, the client can
 issue actual put-get request(s) on the channel.
 
-    struct channelPutGetRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x00 for PUT_GET; 0x10 mask for DESTROY;
-        BitSet toPutBitSet;
-        PVField pvPutStructureData;
-    };
-    
-    struct channelPutGetResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] PVField pvGetStructureData;
-    };
+```c
+struct channelPutGetRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x00 for PUT_GET; 0x10 mask for DESTROY;
+    BitSet toPutBitSet;
+    PVField pvPutStructureData;
+};
+
+struct channelPutGetResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] PVField pvGetStructureData;
+};
+```
 
 :::{table} Channel put-get request
 :align: center
@@ -838,18 +870,20 @@ A "get-put" request retrieves the remote put structure. This MAY be used
 by user applications to show data that was set the last time by the
 application.
 
-    struct channelGetPutRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x80;
-    };
-    
-    struct channelGetPutResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] PVField pvPutStructureData;
-    };
+```c
+struct channelGetPutRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x80;
+};
+
+struct channelGetPutResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] PVField pvPutStructureData;
+};
+```
 
 :::{table} Channel get put request
 :align: center
@@ -875,18 +909,20 @@ application.
 A "get-get" request retrieves remote get structure. This MAY be used by
 user applications to show data that was retrieved the last time.
 
-    struct channelGetGetRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x40;
-    };
-    
-    struct channelGetGetResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] PVField pvGetStructureData;
-    };
+```c
+struct channelGetGetRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x40;
+};
+
+struct channelGetGetResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] PVField pvGetStructureData;
+};
+```
 
 :::{table} Channel get get request
 :align: center
@@ -920,20 +956,22 @@ values. Requests allow a client agent to: retrieve (get) and set (put)
 data from/to the array, and to change the array's length (number of
 valid elements in the array).
 
-    struct channelArrayRequestInit {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x08;
-        FieldDesc pvRequestIF;
-        PVField pvRequest;
-    };
-    
-    struct channelArrayResponseInit {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] FieldDesc pvArrayIF;
-    };
+```c
+struct channelArrayRequestInit {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x08;
+    FieldDesc pvRequestIF;
+    PVField pvRequest;
+};
+
+struct channelArrayResponseInit {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] FieldDesc pvArrayIF;
+};
+```
 
 :::{table} Channel array init request
 :align: center
@@ -961,20 +999,22 @@ valid elements in the array).
 After an array request is successfully initialized, the client can issue
 the actual array request(s).
 
-    struct channelGetArrayRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x40 mask for GET; 0x10 mask for DESTROY;
-        size offset;
-        size count;
-    };
-    
-    struct channelGetArrayResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] PVField pvArrayData;
-    };
+```c
+struct channelGetArrayRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x40 mask for GET; 0x10 mask for DESTROY;
+    size offset;
+    size count;
+};
+
+struct channelGetArrayResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] PVField pvArrayData;
+};
+```
 
 :::{table} Channel array get request
 :align: center
@@ -999,20 +1039,21 @@ the actual array request(s).
 | pvArrayData | Data array.                             |
 :::
 
+```c
+struct channelPutArrayRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x00 mask for PUT; 0x10 mask for DESTROY;
+    size offset;
+    PVField pvArrayData;
+};
 
-    struct channelPutArrayRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x00 mask for PUT; 0x10 mask for DESTROY;
-        size offset;
-        PVField pvArrayData;
-    };
-    
-    struct channelPutArrayResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-    };
+struct channelPutArrayResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+};
+```
 
 :::{table} Channel array put request
 :align: center
@@ -1036,20 +1077,22 @@ the actual array request(s).
 |     status | Completion status.                      |
 :::
 
+```c
 /// TODO GetLength is missing, fix the codes \!\!\!
 
-    struct channelSetLengthRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x80 mask for SET_LENGTH; 0x10 mask for DESTROY;
-        size length;
-    };
-    
-    struct channelSetLengthResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-    };
+struct channelSetLengthRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x80 mask for SET_LENGTH; 0x10 mask for DESTROY;
+    size length;
+};
+
+struct channelSetLengthResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+};
+```
 
 :::{table} Channel array set length request
 :align: center
@@ -1077,11 +1120,13 @@ the actual array request(s).
 A "destroy request" messages is used destroy any request instance, i.e.
 an instance with requestID.
 
-    // destroys any request with given requestID
-    struct destroyRequest {
-        int serverChannelID;
-        int requestID;
-    };
+```c
+// destroys any request with given requestID
+struct destroyRequest {
+    int serverChannelID;
+    int requestID;
+};
+```
 
 :::{table} Destroy request
 :align: center
@@ -1099,19 +1144,21 @@ that the computation actions associated with a channel should be
 executed. In the language of EPICS, this means that the channel should
 be "processed".
 
-    struct channelProcessRequestInit {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x08;
-        FieldDesc pvRequestIF;
-        [if serverStatusIF != NULL_TYPE_CODE] PVField pvRequest;
-    };
-    
-    struct channelProcessResponseInit {
-        int requestID;
-        byte subcommand;
-        Status status;
-    };
+```c
+struct channelProcessRequestInit {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x08;
+    FieldDesc pvRequestIF;
+    [if serverStatusIF != NULL_TYPE_CODE] PVField pvRequest;
+};
+
+struct channelProcessResponseInit {
+    int requestID;
+    byte subcommand;
+    Status status;
+};
+```
 
 :::{table} Channel process init request
 :align: center
@@ -1138,17 +1185,19 @@ be "processed".
 After a process request is successfully initialized, the client can
 issue the actual process request(s).
 
-    struct channelProcessRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x00 mask for PROCESS; 0x10 mask for DESTROY;
-    };
-    
-    struct channelProcessResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-    };
+```c
+struct channelProcessRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x00 mask for PROCESS; 0x10 mask for DESTROY;
+};
+
+struct channelProcessResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+};
+```
 
 :::{table} Channel process request
 :align: center
@@ -1175,17 +1224,19 @@ issue the actual process request(s).
 Thus message is used to retrieve a channel's type introspection data,
 i.e. a description of all the channel's fields and their data types.
 
-    struct channelGetFieldRequest {
-        int serverChannelID;
-        int requestID;
-        string subFieldName;  // entire record if empty
-    };
-    
-    struct channelGetFieldResponse {
-        int requestID;
-        Status status;
-        [if status.type == OK | WARNING] FieldDesc subFieldIF;
-    };
+```c
+struct channelGetFieldRequest {
+    int serverChannelID;
+    int requestID;
+    string subFieldName;  // entire record if empty
+};
+
+struct channelGetFieldResponse {
+    int requestID;
+    Status status;
+    [if status.type == OK | WARNING] FieldDesc subFieldIF;
+};
+```
 
 :::{table} Get channel introspection data request
 :align: center
@@ -1213,11 +1264,13 @@ A "message" message is used by a server to provide to a client human
 readable text regarding the status of a specific request. This message
 MUST NOT be used to report request completion status.
 
-    struct message {
-        int requestID;
-        byte messageType; // info = 0, warning = 1, error = 2, fatalError = 3
-        string message;
-    };
+```c
+struct message {
+    int requestID;
+    byte messageType; // info = 0, warning = 1, error = 2, fatalError = 3
+    string message;
+};
+```
 
 :::{table} Message response
 :align: center
@@ -1238,19 +1291,21 @@ This message code never used, and considered deprecated.
 The "channel RPC" set of messages are used to provide remote procedure
 call (RPC) support over pvAccess.
 
-    struct channelRPCRequestInit {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x08;
-        FieldDesc pvRequestIF;
-        PVField pvRequest;
-    };
-    
-    struct channelRPCResponseInit {
-        int requestID;
-        byte subcommand;
-        Status status;
-    };
+```c
+struct channelRPCRequestInit {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x08;
+    FieldDesc pvRequestIF;
+    PVField pvRequest;
+};
+
+struct channelRPCResponseInit {
+    int requestID;
+    byte subcommand;
+    Status status;
+};
+```
 
 :::{table} Channel RPC init request
 :align: center
@@ -1277,21 +1332,23 @@ call (RPC) support over pvAccess.
 After a RPC request is successfully initialized, the client can issue
 actual RPC request(s).
 
-    struct channelRPCRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand = 0x00 mask for RPC; 0x10 mask for DESTROY;
-        FieldDesc pvStructureIF;
-        PVField pvStructureData;
-    };
-    
-    struct channelRPCResponse {
-        int requestID;
-        byte subcommand;
-        Status status;
-        [if status.type == OK | WARNING] FieldDesc pvResponseIF;
-        [if status.type == OK | WARNING] PVField pvResponseData;
-    };
+```c
+struct channelRPCRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand = 0x00 mask for RPC; 0x10 mask for DESTROY;
+    FieldDesc pvStructureIF;
+    PVField pvStructureData;
+};
+
+struct channelRPCResponse {
+    int requestID;
+    byte subcommand;
+    Status status;
+    [if status.type == OK | WARNING] FieldDesc pvResponseIF;
+    [if status.type == OK | WARNING] PVField pvResponseData;
+};
+```
 
 :::{table} Channel RPC request
 :align: center
@@ -1322,11 +1379,13 @@ actual RPC request(s).
 A "cancel request" messages is used cancel any pending request, i.e. an
 instance with requestID.
 
-    // cancel any request with given requestID
-    struct cancelRequest {
-        int serverChannelID;
-        int requestID;
-    };
+```c
+// cancel any request with given requestID
+struct cancelRequest {
+    int serverChannelID;
+    int requestID;
+};
+```
 
 :::{table} Cancel request
 :align: center
@@ -1370,10 +1429,12 @@ This is an OS dependent process.  A suggested start point is to consider
 a match if either forwarderAddress or socket bind address is "0.0.0.0"
 (INADDR_ANY).  Identical forwarderAddress and bind address also match.
 
-    // Indicate who forwarded the search request
-    struct originTag {
-        byte[16] forwarderAddress;
-    };
+```c
+// Indicate who forwarded the search request
+struct originTag {
+    byte[16] forwarderAddress;
+};
+```
 
 ## Control Messages
 

--- a/pv-access/Protocol-Messages.md
+++ b/pv-access/Protocol-Messages.md
@@ -33,6 +33,9 @@ if it were expressed by the following structure:
 The semantics of these message header components are given in the
 following table.
 
+:::{table} pvAccess Header Members
+:align: center
+
 |         Member | Description                                             |
 | -------------: | ------------------------------------------------------- |
 |          magic | pvAccess protocol magic code. This MUST always be 0xCA. |
@@ -40,9 +43,11 @@ following table.
 |          flags | Message flags.                                          |
 | messageCommand | Message command (i.e. create, get, put, process, etc.). |
 |    payloadSize | Message payload size (non-aligned, in bytes).           |
+:::
 
-pvAccess Header Members.
 
+:::{table} pvAccess Header Flags Description
+:align: center
 
 | bit   | Value | Description                            |
 | ---   | ----- | -----------                            |
@@ -57,8 +62,7 @@ pvAccess Header Members.
 | 6     | 1     | Message sent by server                 |
 | 7     | 0     | Little endian byte order               |
 | 7     | 1     | Big endian byte order                  |
-
-pvAccess Header Flags Description.
+:::
 
 Between two segmented messages of the same set there MUST NOT be any
 other application message than the segmented message of the same set.
@@ -121,6 +125,9 @@ and may use this information to more quickly retry unanswered CMD_SEARCH message
         [if serverStatusIF != NULL_TYPE_CODE] PVField serverStatus;
     };
 
+:::{table} Beacon Message Members
+:align: center
+
 |            Member | Description                                                                                       |
 | ----------------: | ------------------------------------------------------------------------------------------------- |
 |              guid | Server GUID (Globally Unique Identifier). MUST change every restart.                              |
@@ -132,8 +139,7 @@ and may use this information to more quickly retry unanswered CMD_SEARCH message
 |          protocol | Protocol/transport name (e.g. "tcp" for standard pvAccess TCP/IP communication).                  |
 |    serverStatusIF | Optional server status Field description, NULL\_TYPE\_CODE MUST be used indicate absence of data. |
 |      serverStatus | Optional server data.                                                                             |
-
-Beacon Message Members.
+:::
 
 When a pvAccess server is started it MUST begin emitting beacons.
 Clients MUST monitor all beacons. A beacon received from an as yet
@@ -205,15 +211,19 @@ In the connectionValidationResponse, the client selects one of these.
 For "anonymous" or "x509", no further detail is required and the `FieldDesc` is 0xFF for the 'null' type code with no `PVField`.
 For "ca", a structure with string elements "user" and "host" needs to follow.
 
+:::{table} Connection Validation Request Message Members
+:align: center
+
 |                             Member | Description                                                                |
 | ---------------------------------: | -------------------------------------------------------------------------- |
 |            serverReceiveBufferSize | Server receive buffer size in bytes.                                       |
 |      serverReceiveSocketBufferSize | Server socket buffer size in bytes.                                        |
 | serverIntrospectionRegistryMaxSize | Maximum number of introspection registry entries server is able to handle. |
 |                             authNZ | List of supported authentication modes                                     |
+:::
 
-Connection Validation Request Message
-Members.
+:::{table} Connection Validation Response Message Members
+:align: center
 
 |                             Member | Description                                                                |
 | ---------------------------------: | -------------------------------------------------------------------------- |
@@ -221,8 +231,10 @@ Members.
 |      clientReceiveSocketBufferSize | Client socket buffer size in bytes.                                        |
 | clientIntrospectionRegistryMaxSize | Maximum number of introspection registry entries client is able to handle. |
 |                      connectionQoS | Connection QoS parameters.                                                 |
+:::
 
-Connection Validation Response Message Members.
+:::{table} Connection QoS Parameters Description
+:align: center
 
 |   bit | Description               |
 | ----: | ------------------------- |
@@ -232,8 +244,7 @@ Connection Validation Response Message Members.
 |     9 | Throughput priority.      |
 |    10 | Enable compression.       |
 | 11-15 | Unused, MUST be 0.        |
-
-Connection QoS Parameters Description.
+:::
 
 Each Quality of Service (QoS) parameter value REQUIRES a separate TCP/IP
 connection. If the Low-latency priority bit is set, this indicates
@@ -258,17 +269,21 @@ is still valid.
         byte[] samePayloadAsInRequest;
     };
 
+:::{table} Echo request message members
+:align: center
+
 |      Member | Description                              |
 | ----------: | ---------------------------------------- |
 | somePayload | Arbitrary payload content, can be empty. |
+:::
 
-Echo request message members.
+:::{table} Echo response message members
+:align: center
 
 |                 Member | Description                         |
 | ---------------------: | ----------------------------------- |
 | samePayloadAsInRequest | Same paylaod as in request message. |
-
-Echo response message members.
+:::
 
 Version 1 servers do not support the payload and will always send an empty reply.
 Version 2 servers return the payload.
@@ -300,6 +315,9 @@ struct searchRequest {
 };
 ```
 
+:::{table} Search request message members
+:align: center
+
 |           Member | Description                                                                             |
 | ---------------: | --------------------------------------------------------------------------------------- |
 | searchSequenceID | Search sequence ID (counter w/ rollover), can be used by congestion control algorithms. |
@@ -307,8 +325,7 @@ struct searchRequest {
 |         protocol | A set of allowed protocols to respond ("tcp", "tls"). Unrestricted if array is empty.   |
 | searchInstanceID | ID to be used to associate response with the following channel name.                    |
 |      channelName | Non-empty channel name, maximum length of 500 characters.                               |
-
-Search request message members.
+:::
 
 The protocol "tcp" indicates that the client would like to then continue the data communication via a plain TCP connection.
 "tls" indicates that the client can also support an SSL/TLS TCP connection.
@@ -346,6 +363,9 @@ search request (0x03) message.
         int[] searchInstanceIDs;
     };
 
+:::{table} Search response message members
+:align: center
+
 |            Member | Description                                                                       |
 | ----------------: | --------------------------------------------------------------------------------- |
 |  searchSequenceID | Search sequence ID, same as specified in search request.                          |
@@ -354,8 +374,7 @@ search request (0x03) message.
 |        serverPort | Server port (e.g. in case of IP transport socket port where server is listening). |
 |          protocol | Protocol name, "tcp" for standard pvAccess TCP/IP communication, "tls" for secure TCP |
 | searchInstanceIDs | IDs, associated with names in the request, relevant to this response.             |
-
-Search response message members.
+:::
 
 A client MUST examine the protocol member field to verify it supports
 the given exchange protocol; if not, the search response is ignored.
@@ -420,20 +439,22 @@ Each channel instance MUST be bound only to one connection.
         // [if status.type == OK | WARNING] short accessRights; // never used
     };
 
+:::{table} Create channel request message members
+:align: center
+
 |          Member | Description                                                                        |
 | --------------: | ---------------------------------------------------------------------------------- |
 | clientChannelID | Client generated channel ID.                                                       |
 |     channelName | Name of the channel to be created, non-empty and maximum length of 500 characters. |
-
-Create channel request message members.
-
+:::
 
 The `createChannelRequest.channels` array starts with a `short` count,
 not using the normal size encoding.
 Current PVA server implementations only support requests for creating
 a single channel, i.e. the `count` must be 1.
 
-
+:::{table} Create channel response (per channel) message members
+:align: center
 
 |          Member | Description                                     |
 | --------------: | ----------------------------------------------- |
@@ -441,8 +462,7 @@ a single channel, i.e. the `count` must be 1.
 | serverChannelID | Server generated channel ID.                    |
 |          status | Completion status.                              |
 |    accessRights | Access rights (TBD).                            |
-
-Create channel response (per channel) message members.
+:::
 
 :::{note}
 A server MUST store the clientChannelID and respond with its value
@@ -472,19 +492,23 @@ side when it lost a channel on its client side.
         int clientChannelID;
     };
 
-|          Member | Description                                              |
-| --------------: | -------------------------------------------------------- |
-| serverChannelID | Server generated channel ID, same as in create response. |
-| clientChannelID | Client generated channel ID, same as in create request.  |
-
-Destroy channel request.
+:::{table} Destroy channel request
+:align: center
 
 |          Member | Description                                              |
 | --------------: | -------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create response. |
 | clientChannelID | Client generated channel ID, same as in create request.  |
+:::
 
-Destroy channel response.
+:::{table} Destroy channel response
+:align: center
+
+|          Member | Description                                              |
+| --------------: | -------------------------------------------------------- |
+| serverChannelID | Server generated channel ID, same as in create response. |
+| clientChannelID | Client generated channel ID, same as in create request.  |
+:::
 
 If the request (clientChannelID, serverChannelID) pair does not match,
 the server MUST respond with an error status. The server MAY break its
@@ -527,6 +551,9 @@ channel.
         [if status.type == OK | WARNING] FieldDesc pvStructureIF;
     };
 
+:::{table} Channel get init request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -534,8 +561,10 @@ channel.
 |      subcommand | 0x08                                                             |
 |     pvRequestIF | pvRequest Field description.                                     |
 |       pvRequest | pvRequest structure.                                             |
+:::
 
-Channel get init request.
+:::{table} Channel get init response
+:align: center
 
 |        Member | Description                                     |
 | ------------: | ----------------------------------------------- |
@@ -543,8 +572,7 @@ Channel get init request.
 |    subcommand | 0x08, same as in request message.               |
 |        status | Completion status.                              |
 | pvStructureIF | pvStructure (data container) Field description. |
-
-Channel get init response.
+:::
 
 After a get request is successfully initialized, the client can issue
 actual get request(s).
@@ -563,13 +591,18 @@ actual get request(s).
         [if status.type == OK | WARNING] PVField pvStructureData;
     };
 
+:::{table} Channel get request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in init message.                             |
 |      subcommand | 0x00 for GET, additional 0x10 mask for DESTROY.                  |
+:::
 
-Channel get request.
+:::{table} Channel get response
+:align: center
 
 |          Member | Description                             |
 | --------------: | --------------------------------------- |
@@ -578,8 +611,7 @@ Channel get request.
 |          status | Completion status.                      |
 |   changedBitSet | Changed BitSet for pvStructureData.     |
 | pvStructureData | Data structure.                         |
-
-Channel get response.
+:::
 
 Most implementations send a 0x00 subcommand to GET data,
 but based on the original protocol documentation 0x40
@@ -611,6 +643,9 @@ channel.
         [if status.type == OK | WARNING] FieldDesc pvPutStructureIF;
     };
 
+:::{table} Channel put init request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -618,9 +653,10 @@ channel.
 |      subcommand | 0x08                                                             |
 |     pvRequestIF | pvRequest Field description.                                     |
 |       pvRequest | pvRequest structure.                                             |
+:::
 
-Channel put init
-request.
+:::{table} Channel put init response
+:align: center
 
 |           Member | Description                                        |
 | ---------------: | -------------------------------------------------- |
@@ -628,8 +664,7 @@ request.
 |       subcommand | 0x08, same as in request message.                  |
 |           status | Completion status.                                 |
 | pvPutStructureIF | pvPutStructure (data container) Field description. |
-
-Channel put init response.
+:::
 
 After a put request is successfully initialized, the client can issue
 actual put request(s) on the channel.
@@ -648,6 +683,9 @@ actual put request(s) on the channel.
         Status status;
     };
 
+:::{table} Channel put request
+:align: center
+
 |             Member | Description                                                      |
 | -----------------: | ---------------------------------------------------------------- |
 |    serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -655,16 +693,17 @@ actual put request(s) on the channel.
 |         subcommand | 0x00 for PUT, additional 0x10 mask for DESTROY.                  |
 |        toPutBitSet | To-put BitSet for pvPutStructureData.                            |
 | pvPutStructureData | Data to put structure.                                           |
+:::
 
-Channel put request.
+:::{table} Channel put response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 | subcommand | Same as in request message.             |
 |     status | Completion status.                      |
-
-Channel put response.
+:::
 
 A "get-put" request retrieves the remote put structure. This MAY be used
 by user applications to show data that was set the last time by the
@@ -685,13 +724,18 @@ application.
             PVField pvStructureData;
     };
 
+:::{table} Channel get put request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in init message.                             |
 |      subcommand | 0x40.                                                            |
+:::
 
-Channel get put request.
+:::{table} Channel get put response
+:align: center
 
 |             Member | Description                             |
 | -----------------: | --------------------------------------- |
@@ -700,8 +744,7 @@ Channel get put request.
 |             status | Completion status.                      |
 | returnedDataBitSet | Which fields are provided in data.      |
 | pvStructureData    | The returned data.                      |
-
-Channel get put response.
+:::
 
 ### CMD_PUT_GET (0x0C)
 
@@ -726,6 +769,9 @@ so that the get reflects changes in the process variable's state.
         [if status.type == OK | WARNING] FieldDesc pvGetStructureIF;
     };
 
+:::{table} Channel put-get init request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -733,9 +779,10 @@ so that the get reflects changes in the process variable's state.
 |      subcommand | 0x08                                                             |
 |     pvRequestIF | pvRequest Field description.                                     |
 |       pvRequest | pvRequest structure.                                             |
+:::
 
-Channel put-get init
-request.
+:::{table} Channel put-get init response
+:align: center
 
 |           Member | Description                                        |
 | ---------------: | -------------------------------------------------- |
@@ -744,8 +791,7 @@ request.
 |           status | Completion status.                                 |
 | pvPutStructureIF | pvPutStructure (data container) Field description. |
 | pvGetStructureIF | pvGetStructure (data container) Field description. |
-
-Channel put-get init response.
+:::
 
 After a put-get request is successfully initialized, the client can
 issue actual put-get request(s) on the channel.
@@ -765,6 +811,9 @@ issue actual put-get request(s) on the channel.
         [if status.type == OK | WARNING] PVField pvGetStructureData;
     };
 
+:::{table} Channel put-get request
+:align: center
+
 |             Member | Description                                                      |
 | -----------------: | ---------------------------------------------------------------- |
 |    serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -772,8 +821,10 @@ issue actual put-get request(s) on the channel.
 |         subcommand | 0x00 for PUT\_GET, additional 0x01 mask for DESTROY.             |
 |        toPutBitSet | To-put BitSet for pvPutStructureData.                            |
 | pvPutStructureData | Data to put structure.                                           |
+:::
 
-Channel put-get request.
+:::{table} Channel put-get response
+:align: center
 
 |             Member | Description                             |
 | -----------------: | --------------------------------------- |
@@ -781,8 +832,7 @@ Channel put-get request.
 |         subcommand | Same as in request message.             |
 |             status | Completion status.                      |
 | pvGetStructureData | Get data structure.                     |
-
-Channel put-get response.
+:::
 
 A "get-put" request retrieves the remote put structure. This MAY be used
 by user applications to show data that was set the last time by the
@@ -801,13 +851,18 @@ application.
         [if status.type == OK | WARNING] PVField pvPutStructureData;
     };
 
+:::{table} Channel get put request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in init message.                             |
 |      subcommand | 0x80.                                                            |
+:::
 
-Channel get put request.
+:::{table} Channel get put response
+:align: center
 
 |             Member | Description                             |
 | -----------------: | --------------------------------------- |
@@ -815,8 +870,7 @@ Channel get put request.
 |         subcommand | Same as in request message.             |
 |             status | Completion status.                      |
 | pvPutStructureData | Remote put data structure.              |
-
-Channel get put response.
+:::
 
 A "get-get" request retrieves remote get structure. This MAY be used by
 user applications to show data that was retrieved the last time.
@@ -834,13 +888,18 @@ user applications to show data that was retrieved the last time.
         [if status.type == OK | WARNING] PVField pvGetStructureData;
     };
 
+:::{table} Channel get get request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in init message.                             |
 |      subcommand | 0x40.                                                            |
+:::
 
-Channel get get request.
+:::{table} Channel get get response
+:align: center
 
 |             Member | Description                             |
 | -----------------: | --------------------------------------- |
@@ -848,8 +907,7 @@ Channel get get request.
 |         subcommand | Same as in request message.             |
 |             status | Completion status.                      |
 | pvGetStructureData | Remote get data structure.              |
-
-Channel get get response.
+:::
 
 ```{include} ./Protocol-Operation-Monitor.md
 :heading-offset: 2
@@ -877,6 +935,9 @@ valid elements in the array).
         [if status.type == OK | WARNING] FieldDesc pvArrayIF;
     };
 
+:::{table} Channel array init request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -884,8 +945,10 @@ valid elements in the array).
 |      subcommand | 0x08                                                             |
 |     pvRequestIF | pvRequest Field description.                                     |
 |       pvRequest | pvRequest structure.                                             |
+:::
 
-Channel array init request.
+:::{table} Channel array init response
+:align: center
 
 |     Member | Description                                 |
 | ---------: | ------------------------------------------- |
@@ -893,8 +956,7 @@ Channel array init request.
 | subcommand | 0x08, same as in request message.           |
 |     status | Completion status.                          |
 |  pvArrayIF | pvArray (data container) Field description. |
-
-Channel array init response.
+:::
 
 After an array request is successfully initialized, the client can issue
 the actual array request(s).
@@ -914,6 +976,9 @@ the actual array request(s).
         [if status.type == OK | WARNING] PVField pvArrayData;
     };
 
+:::{table} Channel array get request
+:align: center
+
 |          Member | Description                                                                |
 | --------------: | -------------------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response.           |
@@ -921,8 +986,10 @@ the actual array request(s).
 |      subcommand | 0x40 for GET, additional 0x10 mask for DESTROY.                            |
 |          offset | Offset from the beginning of the array.                                    |
 |           count | Number of elements requested, 0 means form offset to the end of the array. |
+:::
 
-Channel array get request.
+:::{table} Channel array get response
+:align: center
 
 |      Member | Description                             |
 | ----------: | --------------------------------------- |
@@ -930,8 +997,8 @@ Channel array get request.
 |  subcommand | Same as in request message.             |
 |      status | Completion status.                      |
 | pvArrayData | Data array.                             |
+:::
 
-Channel array get response.
 
     struct channelPutArrayRequest {
         int serverChannelID;
@@ -947,6 +1014,9 @@ Channel array get response.
         Status status;
     };
 
+:::{table} Channel array put request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -954,16 +1024,17 @@ Channel array get response.
 |      subcommand | 0x00 for PUT, additional 0x10 mask for DESTROY.                  |
 |          offset | Offset from the beginning of the array.                          |
 |     pvArrayData | Subarray to be put.                                              |
+:::
 
-Channel array put request.
+:::{table} Channel array put response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 | subcommand | Same as in request message.             |
 |     status | Completion status.                      |
-
-Channel array put response.
+:::
 
 /// TODO GetLength is missing, fix the codes \!\!\!
 
@@ -980,22 +1051,26 @@ Channel array put response.
         Status status;
     };
 
+:::{table} Channel array set length request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in init message.                             |
 |      subcommand | 0x40 for GET, additional 0x10 mask for DESTROY.                  |
 |          length | New length.                                                      |
+:::
 
-Channel array set length request.
+:::{table} Channel array set length response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 | subcommand | Same as in request message.             |
 |     status | Completion status.                      |
-
-Channel array set length response.
+:::
 
 ### CMD_DESTROY_REQUEST (0x0F)
 
@@ -1008,12 +1083,14 @@ an instance with requestID.
         int requestID;
     };
 
+:::{table} Destroy request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in request init message.                     |
-
-Destroy request.
+:::
 
 ### CMD_PROCESS (0x10)
 
@@ -1036,6 +1113,9 @@ be "processed".
         Status status;
     };
 
+:::{table} Channel process init request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -1043,16 +1123,17 @@ be "processed".
 |      subcommand | 0x08                                                             |
 |     pvRequestIF | Optional pvRequest Field description, NULL\_TYPE\_CODE is none.  |
 |       pvRequest | Optional pvRequest structure.                                    |
+:::
 
-Channel process init request.
+:::{table} Channel process init response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 | subcommand | 0x08, same as in request message.       |
 |     status | Completion status.                      |
-
-Channel process init response.
+:::
 
 After a process request is successfully initialized, the client can
 issue the actual process request(s).
@@ -1069,21 +1150,25 @@ issue the actual process request(s).
         Status status;
     };
 
+:::{table} Channel process request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in init message.                             |
 |      subcommand | 0x00 for PROCESS, additional 0x10 mask for DESTROY.              |
+:::
 
-Channel proces request.
+:::{table} Channel process response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 | subcommand | Same as in request message.             |
 |     status | Completion status.                      |
-
-Channel process response.
+:::
 
 ### CMD_GET_FIELD (0x11)
 
@@ -1102,21 +1187,25 @@ i.e. a description of all the channel's fields and their data types.
         [if status.type == OK | WARNING] FieldDesc subFieldIF;
     };
 
+:::{table} Get channel introspection data request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Client generated request ID.                                     |
 |    subFieldName | Name of the subfield to get or entire record if empty.           |
+:::
 
-Get channel introspection data request.
+:::{table} Get channel introspection data response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 |     status | Completion status.                      |
 | subFieldIF | Requested field introspection data.     |
-
-Get channel introspection data response.
+:::
 
 ### CMD_MESSAGE (0x12)
 
@@ -1130,13 +1219,15 @@ MUST NOT be used to report request completion status.
         string message;
     };
 
+:::{table} Message response
+:align: center
+
 |      Member | Description        |
 | ----------: | ------------------ |
 |   requestID | Request ID.        |
 | messageType | Message type enum. |
 |     message | Message.           |
-
-Message response.
+:::
 
 ### CMD_MULTIPLE_DATA (0x13)
 
@@ -1161,6 +1252,9 @@ call (RPC) support over pvAccess.
         Status status;
     };
 
+:::{table} Channel RPC init request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -1168,16 +1262,17 @@ call (RPC) support over pvAccess.
 |      subcommand | 0x08                                                             |
 |     pvRequestIF | pvRequest Field description.                                     |
 |       pvRequest | pvRequest structure.                                             |
+:::
 
-Channel RPC init request.
+:::{table} Channel RPC init response
+:align: center
 
 |     Member | Description                             |
 | ---------: | --------------------------------------- |
 |  requestID | Request ID, same as in request message. |
 | subcommand | 0x08, same as in request message.       |
 |     status | Completion status.                      |
-
-Channel RPC init response.
+:::
 
 After a RPC request is successfully initialized, the client can issue
 actual RPC request(s).
@@ -1198,6 +1293,9 @@ actual RPC request(s).
         [if status.type == OK | WARNING] PVField pvResponseData;
     };
 
+:::{table} Channel RPC request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
@@ -1205,8 +1303,10 @@ actual RPC request(s).
 |      subcommand | 0x00 for RPC, additional 0x10 mask for DESTROY.                  |
 |   pvStructureIF | pvStructureData Field description.                               |
 | pvStructureData | Argument data structure.                                         |
+:::
 
-Channel RPC request.
+:::{table} Channel RPC response
+:align: center
 
 |         Member | Description                             |
 | -------------: | --------------------------------------- |
@@ -1215,8 +1315,7 @@ Channel RPC request.
 |         status | Completion status.                      |
 |   pvResponseIF | pvResponseDataField description.        |
 | pvResponseData | Response data structure.                |
-
-Channel RPC response.
+:::
 
 ### CMD_CANCEL_REQUEST (0x15)
 
@@ -1229,14 +1328,14 @@ instance with requestID.
         int requestID;
     };
 
+:::{table} Cancel request
+:align: center
+
 |          Member | Description                                                      |
 | --------------: | ---------------------------------------------------------------- |
 | serverChannelID | Server generated channel ID, same as in create channel response. |
 |       requestID | Request ID, same as in request init message.                     |
-
-Cancel request.
-
-
+:::
 
 ### CMD_ORIGIN_TAG (0x16)
 
@@ -1312,18 +1411,20 @@ order.
 The client's decoding byte order for messages received from the server depends on the payload size field value as
 follows:
 
+:::{table} Client Decoding
+:align: center
+
 | Payload Size Field Value | Meaning                                                                                                         |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | 0x00000000               | Client MUST decode all the messages received via this connection using server's selected byte order.            |
 | 0xFFFFFFFF               | Client MUST decode all the messages sent received this connection as indicated by each message byte order flag. |
+:::
 
 :::{note}
 Existing implementations have been found to ignore the "payload size".
 They decode each received message based on the byte order bit in the message header flags field,
 i.e., they always behave as per "payload size" = 0xFFFFFFFF.
 :::
-
-Client Decoding
 
 This MUST be the first message sent by a server when connection is
 established. For connection-less protocols this message is not sent and

--- a/pv-access/Protocol-Messages.md
+++ b/pv-access/Protocol-Messages.md
@@ -1,44 +1,7 @@
 # Protocol messages specification
 
-[Back to main](protocol)
-
-1.  [Protocol Messages](#protocol-messages)
-    1.  [Message header](#message-header)
-2. [Application Messages](#application-messages)
-    1.  [CMD_BEACON (0x00)](#cmd_beacon-0x00)
-    2.  [CMD_CONNECTION_VALIDATION (0x01)](#cmd_connection_validation-0x01)
-    3.  [CMD_ECHO (0x02)](#cmd_echo-0x02)
-    4.  [CMD_SEARCH (0x03)](#cmd_search-0x03)
-    5.  [CMD_SEARCH_RESPONSE (0x04)](#cmd_search_response-0x04)
-    6.  [CMD_AUTHNZ (0x05)](#cmd_authnz-0x05)
-    7.  [CMD_ACL_CHANGE (0x06)](#cmd_acl_change-0x06)
-    8.  [CMD_CREATE_CHANNEL (0x07)](#cmd_create_channel-0x07)
-    9.  [CMD_DESTROY_CHANNEL (0x08)](#cmd_destroy_channel-0x08)
-    10.  [CMD_CONNECTION_VALIDATED (0x09)](#cmd_connection_validated-0x09)
-    11.  [CMD_GET (0x0A)](#cmd_get-0x0a)
-    12.  [CMD_PUT (0x0B)](#cmd_put-0x0b)
-    13. [CMD_PUT_GET (0x0C)](#cmd_put_get-0x0c)
-    14. [CMD_MONITOR (0x0D)](Protocol-Operation-Monitor)
-    15. [CMD_ARRAY (0x0E)](#cmd_array-0x0e)
-    16. [CMD_DESTROY_REQUEST (0xF)](#cmd_destroy_request-0x0f)
-    17. [CMD_PROCESS (0x10)](#cmd_process-0x10)
-    18. [CMD_GET_FIELD (0x11)](#cmd_get_field-0x11)
-    19. [CMD_MESSAGE (0x12)](#cmd_message-0x12)
-    20. [CMD_MULTIPLE_DATA (0x13)](#cmd_multiple_data-0x13)
-    21. [CMD_RPC (0x14)](#cmd_rpc-0x14)
-    22. [CMD_CANCEL_REQUEST (0x15)](#cmd_cancel_request-0x15)
-    23. [CMD_ORIGIN_TAG (0x16)](#cmd_origin_tag-0x16)
-3. [Control Messages](#control-messages)
-    1.  [Mark Total Byte Sent
-        (0x00)](#mark-total-byte-sent-0x00)
-    2.  [Acknowledge Total Bytes Received
-        (0x01)](#acknowledge-total-bytes-received-0x01)
-    3.  [Set byte order
-        (0x02)](#set-byte-order-0x02)
-    4.  [Echo request
-        (0x03)](#echo-request-0x03)
-    5.  [Echo response
-        (0x04)](#echo-response-0x04)
+```{contents}
+```
 
 The pvAccess protocol uses two protocol message types:
 

--- a/pv-access/Protocol-Messages.md
+++ b/pv-access/Protocol-Messages.md
@@ -1,4 +1,4 @@
-# pvAccess Protocol Specification
+# Protocol messages specification
 
 [Back to main](protocol)
 
@@ -40,8 +40,6 @@
     5.  [Echo response
         (0x04)](#echo-response-0x04)
 
-## Protocol Messages
-
 The pvAccess protocol uses two protocol message types:
 
   - Control messages. These include flow control and have no payload
@@ -56,7 +54,7 @@ specification versions of the protocol. Every implementation of the
 protocol MUST clearly indicate the most recent specification version to
 which it is conformant, using the version URLs above.
 
-### Message Header
+## Message Header
 
 Each protocol message has a fixed 8-byte header that MUST be encoded as
 if it were expressed by the following structure:
@@ -482,7 +480,7 @@ a single channel, i.e. the `count` must be 1.
 |    accessRights | Access rights (TBD).                            |
 
 Create channel response (per channel) message members.
- 
+
 :::{note}
 A server MUST store the clientChannelID and respond with its value
 in a destroyChannelMessage when a channel destroy request is requested,
@@ -499,7 +497,7 @@ that was previously created (with a create channel message).
 
 A server may also send this message to the client when the channel is no longer
 available. Examples include a PVA gateway that sends this message from its server
-side when it lost a channel on its client side. 
+side when it lost a channel on its client side.
 
     struct destroyChannelRequest {
         int serverChannelID;
@@ -528,7 +526,7 @@ Destroy channel response.
 If the request (clientChannelID, serverChannelID) pair does not match,
 the server MUST respond with an error status. The server MAY break its
 response into several messages.
- 
+
 :::{note}
 A server MUST send this message to a client to notify the client
 about server-side initiated channel destruction. Subsequently, a client
@@ -889,6 +887,10 @@ Channel get get request.
 | pvGetStructureData | Remote get data structure.              |
 
 Channel get get response.
+
+```{include} ./Protocol-Operation-Monitor.md
+:heading-offset: 2
+```
 
 ### CMD_ARRAY (0x0E)
 

--- a/pv-access/Protocol-Operation-Monitor.md
+++ b/pv-access/Protocol-Operation-Monitor.md
@@ -113,59 +113,59 @@ TODO: describe 'record._options.ackAny' option.
 ## Request Encoding (Client -> Server)
 
 ```c
-    struct channelMonitorRequest {
-        int serverChannelID;
-        int requestID;
-        byte subcommand;
-        if subcommmand&0x08 { // Init
-            StructureDesc pvRequestIF;
-            PVStructure pvRequest;
-            if subcommand&0x80 { // pipeline support
-                int nfree; // initial window size
-            }
-        } else {
-            if subcommand&0x80 { // pipeline support
-                int nfree; // increment window size
-            }
-            if subcommand&0x04 {
-                if subcommand&0x40 {
-                    // subscription start
-                } else {
-                    // subscription stop
-                }
-            }
-            if subcommand&0x10 {
-                // last request (requestID released)
+struct channelMonitorRequest {
+    int serverChannelID;
+    int requestID;
+    byte subcommand;
+    if subcommmand&0x08 { // Init
+        StructureDesc pvRequestIF;
+        PVStructure pvRequest;
+        if subcommand&0x80 { // pipeline support
+            int nfree; // initial window size
+        }
+    } else {
+        if subcommand&0x80 { // pipeline support
+            int nfree; // increment window size
+        }
+        if subcommand&0x04 {
+            if subcommand&0x40 {
+                // subscription start
+            } else {
+                // subscription stop
             }
         }
-    };
+        if subcommand&0x10 {
+            // last request (requestID released)
+        }
+    }
+};
 ```
 
 ## Response Encoding (Server -> Client)
 
 ```c
-    struct channelMonitorResponse {
-        int requestID;
-        byte subcommand;
-        if subcommmand&0x08 { // Init
+struct channelMonitorResponse {
+    int requestID;
+    byte subcommand;
+    if subcommmand&0x08 { // Init
+        Status status;
+        if status.type == OK | WARNING {
+            FieldDesc pvStructureIF;
+        }
+    } else {
+        if subcommand&0x10 {
             Status status;
-            if status.type == OK | WARNING {
-                FieldDesc pvStructureIF;
-            }
-        } else {
-            if subcommand&0x10 {
-                Status status;
-                if ! payloadBuffer.empty() {
-                    BitSet changedBitSet;
-                    PVField pvStructureData;
-                    BitSet overrunBitSet;
-                }
-                // final update (requestID released)
-            } else { // normal update
+            if ! payloadBuffer.empty() {
                 BitSet changedBitSet;
                 PVField pvStructureData;
                 BitSet overrunBitSet;
             }
+            // final update (requestID released)
+        } else { // normal update
+            BitSet changedBitSet;
+            PVField pvStructureData;
+            BitSet overrunBitSet;
         }
-    };
+    }
+};
 ```

--- a/pv-access/Protocol-Operation-Monitor.md
+++ b/pv-access/Protocol-Operation-Monitor.md
@@ -21,17 +21,17 @@ In this state the Server must not send any updates.
 
 ## Normal Operation
 
-After a monitor subscription is established either peer may send non-init messages (subcommand&0xF7)
+After a monitor subscription is established either peer may send non-init messages (`subcommand&0xF7`)
 asynchronously.
 
 A Client may send a channelMonitorRequest which performs up to three actions.
 
-1. subcommand&0x80 indicates an acknowledgement (increment) to the pipeline flow control window.
+1. `subcommand&0x80` indicates an acknowledgement (increment) to the pipeline flow control window.
 
-2. subcommand&0x44==0x44 Changes the subscription state from Stopped to Running.
-   subcommand&0x44==0x04 Changes the subscription state from Running to Stopped.
+2. `subcommand&0x44==0x44` Changes the subscription state from Stopped to Running.
+   `subcommand&0x44==0x04` Changes the subscription state from Running to Stopped.
 
-3. subcommand&0x10 requests that the subscription be terminated.
+3. `subcommand&0x10` requests that the subscription be terminated.
 
 A Server subscription update is a channelMonitorResponse with subcommand==0x00 or 0x10.
 If 0x10 then this update is the last update, and the subscription has ended.
@@ -52,9 +52,9 @@ in the serialized data addressed by bit 0.
 
 standard options
 
-1. 'record._options.queueSize'
-2. 'record._options.pipeline'
-3. 'record._options.ackAny'
+1. `record._options.queueSize`
+2. `record._options.pipeline`
+3. `record._options.ackAny`
 
 ## Pipeline protocol option
 

--- a/pv-access/Protocol-Operation-Monitor.md
+++ b/pv-access/Protocol-Operation-Monitor.md
@@ -1,14 +1,10 @@
-# pvAccess Protocol Specification
-
-[Back to main](protocol)
-
-## CMD_MONITOR (0x0D)
+# CMD_MONITOR (0x0D)
 
 The "channel monitor" set of messages are used by client agents to
 indicate that they wish to be asynchronously informed of changes in the
 state or values of the process variable of a channel.
 
-### Setup
+## Setup
 
 Starting with a valid serverChannelID (cf. Create Channel message), a client first
 sends a channelMonitorRequest with subcommand==0x08 or 0x88 (if using the pipeline protocol).
@@ -23,7 +19,7 @@ and the subscription is established.
 The subscription is initially in the Stopped state.
 In this state the Server must not send any updates.
 
-### Normal Operation
+## Normal Operation
 
 After a monitor subscription is established either peer may send non-init messages (subcommand&0xF7)
 asynchronously.
@@ -52,7 +48,7 @@ The pvStructureData will only contain the complete structure data once,
 it will not repeat data for elements 1 and 2, since they are already contained
 in the serialized data addressed by bit 0.
 
-### pvRequest options
+## pvRequest options
 
 standard options
 
@@ -60,7 +56,7 @@ standard options
 2. 'record._options.pipeline'
 3. 'record._options.ackAny'
 
-### Pipeline protocol option
+## Pipeline protocol option
 
 Usage of the pipeline protocol option requires both sides to agree
 and maintain a flow control window counter indicating the number of
@@ -82,7 +78,7 @@ Each time an update is sent by the server, and received by the client, the count
 The client may send a channelMonitorRequest with subcommand&0x80 and a 'nfree' count
 which is added to the counter.
 
-#### Acknowledgement Algorithm
+### Acknowledgement Algorithm
 
 In this way, the client can manage the rate at which the server can send update.
 

--- a/pv-access/Protocol-Prose.md
+++ b/pv-access/Protocol-Prose.md
@@ -38,9 +38,9 @@ a response is received or the connection is reported to be lost. If an
 echo response is received and transport is marked as unresponsive, then
 transport SHOUD be reported to be responsive.
 
-![Connection State Diagram](img/pvAccessSpec_ConnectionStates.png)
-
-Connection State Diagram.
+```{figure} img/pvAccessSpec_ConnectionStates.png
+Connection State Diagram
+```
 
 When connection is terminated all related resources MUST be freed. On
 the server side all channels including their requests MUST be destroyed
@@ -58,9 +58,9 @@ re-started.
 
 ## Channel Life-cycle
 
-![Channel State Diagram](img/pvAccessSpec_ChannelStates.png)
-
-Channel State Diagram.
+```{figure} img/pvAccessSpec_ChannelStates.png
+Channel State Diagram
+```
 
 When a channel is instantiated by a client application, its state MUST
 be set to a NEVER\_CONNECTED state. This indicates that the channel is
@@ -94,9 +94,9 @@ used anymore.
 
 ## Channel Request Life-cycle
 
-![Channel Request State Diagram](img/pvAccessSpec_RequestStates.png)
-
-Channel Request State Diagram.
+```{figure} img/pvAccessSpec_RequestStates.png
+Channel Request State Diagram
+```
 
 Channel requests (get, put, get-put, RPC, process) have a state. When
 instantiated, they MUST be set to the INIT state. A specific per request

--- a/pv-access/Protocol-Prose.md
+++ b/pv-access/Protocol-Prose.md
@@ -1,15 +1,5 @@
 # Overview
 
-[Back to main](protocol)
-
-1.  [Connection Management](#connection-management)
-2.  [Channel Life-cycle](#channel-life-cycle)
-3.  [Channel Request Life-cycle](#channel-request-life-cycle)
-4.  [Flow Control](#flow-control)
-    1.  [Flow Control Example](#flow-control-example)
-5.  [Channel Discovery](#channel-discovery)
-6.  [Communication Example](#communication-example)
-
 ## Connection Management
 
 pvAccess uses the concept of a "channel" to denote a connection to a
@@ -245,7 +235,7 @@ server where the client issues a get request on a channel.
 |                              | \<----                     | channelGetRequestInit                   |
 | channelGetResponseInit       | \----\>                    |                                         |
 |                              | \<----                     | channelGetRequest                       |
-| channelGetResponse           | \----\>                    |                                         | 
+| channelGetResponse           | \----\>                    |                                         |
 |                              | \<----                     | ...                                     |
 | ...                          | \----\>                    |                                         |
 |                              | \<----                     | destroyRequest                          |

--- a/pv-access/Protocol-Prose.md
+++ b/pv-access/Protocol-Prose.md
@@ -1,4 +1,4 @@
-# pvAccess Protocol Specification
+# Overview
 
 [Back to main](protocol)
 

--- a/pv-access/protocol.md
+++ b/pv-access/protocol.md
@@ -6,7 +6,7 @@ This document was converted from the
 [Public Working Draft, 16-October-2015](https://github.com/epics-base/pvDataWWW/blob/ca3848712682132d67b63c7be0fc63e5b0256f6c/mainPage/pvAccess_Protocol_Specification.html)
 and continues to be updated.
 
-  - Editors:  
+  - Editors:
     * Matej Sekoranja, Cosylab
     * Marty Kraimer, BNL
     * Greg White, SLAC, PSI
@@ -63,32 +63,7 @@ As a special exception, a TCP peer must be disconnected if it does not send a va
 ### Version 0
  * Obsolete version code used by early clients/servers.  Messages are not compatible with >=v1.
 
-## Table of Contents
-
-<div class="toc">
-
-1.  [Overview](#overview)
-2.  [Data Encoding](Protocol-Encoding)
-3.  [Connection Management](Protocol-Prose.md#connection-management)
-4.  [Channel Life-cycle](Protocol-Prose.md#channel-life-cycle)
-5.  [Channel Request Life-cycle](Protocol-Prose.md#channel-request-life-cycle)
-6.  [Flow Control](Protocol-Prose.md#flow-control)
-7.  [Channel Discovery](Protocol-Prose.md#channel-discovery)
-8.  [Communication Example](Protocol-Prose.md#communication-example)
-9.  [Protocol Messages](Protocol-Messages.md#protocol-messages)
-    1.  [Message header](Protocol-Messages.md#message-header)
-10. [Application Messages](Protocol-Messages.md#application-messages)
-11. [Control Messages](Protocol-Messages.md#controlMessages)
-12. [Future Protocol Changes/Updates](#futureProtocolChanges)
-13. [Missing Aspects](#missing)
-
-</div>
-
------
-
-<div id="contents" class="contents">
-
-## Overview
+## Summary
 
 pvAccess is a high-performance network communication protocol. It is
 designed for efficient signal monitoring and the data
@@ -143,6 +118,15 @@ specification and will be specified in future revisions:
   - offset and count fields of channelArray request should be of type
     'size', however 'size' cannot be negative
   - update Communication Example section to show messages
+
+## Specifications
+
+```{toctree}
+:maxdepth: 2
+./Protocol-Prose.md
+./Protocol-Encoding.md
+./Protocol-Messages.md
+```
 
 ## Bibliography
 

--- a/pv-access/protocol.md
+++ b/pv-access/protocol.md
@@ -130,24 +130,17 @@ specification and will be specified in future revisions:
 
 ## Bibliography
 
-bib:caref
 
-EPICS R3.14 Channel Access Reference Manual, J.O. Hill, R. Lange, 2002,
+- EPICS R3.14 Channel Access Reference Manual, J.O. Hill, R. Lange, 2002,
 <http://www.aps.anl.gov/epics/base/R3-14/8-docs/CAref.html>
 
-bib:pvdatarefcpp
-
-EPICS pvDataCPP \[pvData C++ Programmers Reference Manual\], M. Kraimer,
+- EPICS pvDataCPP \[pvData C++ Programmers Reference Manual\], M. Kraimer,
 2011 under development,
 <http://epics-pvdata.sourceforge.net/docbuild/pvDataCPP/tip/documentation/pvDataCPP.html>
 
-bib:pvdatarefjava
-
-EPICS pvDataJava \[pvData Java Programmers Reference Manual\], M.
+- EPICS pvDataJava \[pvData Java Programmers Reference Manual\], M.
 Kraimer, 2011 under development,
 <http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html>
 
-bib:ieee754wiki
-
-IEEE 754-2008, Wikipedia article, April 2012,
+- IEEE 754-2008, Wikipedia article, April 2012,
 <http://en.wikipedia.org/wiki/IEEE_754-1985>


### PR DESCRIPTION
Best viewed commit by commit.

This makes the pvAccess documentation use Sphinx' toctrees instead of relative links, to silence Sphinx warnings. Some headings were modified in order to keep most of the TOC structure
presented to the user.

Also use the `contents` directive instead of a manual TOC with a list of links.

And some other minor changes which I think makes the output a bit more consistent with the rest of the doc.

Thanks @ttkorhonen for converting them over! I might need this documentation someday ^^