### PR TITLE
fix link to msi document, plus a couple of spelling issues

### DIFF
--- a/software/epics-related-software.md
+++ b/software/epics-related-software.md
@@ -172,8 +172,8 @@ SDDS | **ARCHIVED** The Self-Describing Data Sets analysis package | [github.com
 ## IOC Database and Module Management Tools
 | Name | Description | Source Code | Documentation |
 | ---- | ----------- | ----------- | ------------- |
-dbVerbose | Verbose database filter | [apics.anl.gov](https://epics.anl.gov/extensions/dbVerbose/index.php) | [apics.anl.gov](https://epics.anl.gov/extensions/dbVerbose/index.php)
-MSI | Macro substitution and include tool (in Base from 3.14) | [github.com](https://github.com/epics-base) | [epics.anl.gov](https://epics.anl.gov/extensions/msi/index.php)
+dbVerbose | Verbose database filter | [epics.anl.gov](https://epics.anl.gov/extensions/dbVerbose/index.php) | [epics.anl.gov](https://epics.anl.gov/extensions/dbVerbose/index.php)
+MSI | Macro substitution and include tool (in Base from 3.14) | [github.com](https://github.com/epics-base/epics-base) | {doc}`docs.epics-controls.org <epics-base:msi>`
 E3 | ESS EPICS Environment Build System (Not limited to ESS) | [gitlab.esss.lu.se](https://gitlab.esss.lu.se/e3/e3) | [e3.pages.esss.lu.se](http://e3.pages.esss.lu.se)
 EPNix | Build, package, deploy IOCs and EPICS-related software using the Nix package manager | [github.com](https://github.com/epics-extensions/EPNix/) | [github.io](https://epics-extensions.github.io/EPNix/)
 pyExpander | Python macro processing tool | [sourceforge.io](https://pyexpander.sourceforge.io/index.html) | [sourceforge.io](https://sourceforge.net/p/pyexpander/code/ci/default/tree/)


### PR DESCRIPTION
Updated the link to msi doc and replaced a couple of 'apics.anl.gov' with 'epics.anl.gov'.