### PR TITLE
pv-access: describe ID numbers handling

### DIFF
--- a/pv-access/Protocol-Messages.md
+++ b/pv-access/Protocol-Messages.md
@@ -1277,7 +1277,7 @@ struct message {
 
 |      Member | Description        |
 | ----------: | ------------------ |
-|   requestID | Request ID.        |
+|   requestID | Client generated request ID. |
 | messageType | Message type enum. |
 |     message | Message.           |
 :::


### PR DESCRIPTION
Expand description of the several stateful ID numbers used in PVA messages.

Arising from https://github.com/epics-base/pvxs/pull/99#issuecomment-2631543749

@kasemir fyi.