### PR TITLE
modified demo IOC creation after Heinz Junkes' report on email.

### DIFF
--- a/getting-started/installation-linux.rst
+++ b/getting-started/installation-linux.rst
@@ -180,7 +180,7 @@ Create a demo/test ioc to test ca and pva
     make
     cd iocBoot/ioctestIoc
     chmod u+x st.cmd
-    ioctestIoc> ./st.cmd
+    ./st.cmd
     #!../../bin/darwin-x86/testIoc
     < envPaths
     epicsEnvSet("IOC","ioctestIoc")


### PR DESCRIPTION
Heinz wrote: 

in
https://docs.epics-controls.org/en/latest/getting-started/installation-linux.html
there is a sequence:


```
cd $HOME/EPICS/TEST/testIoc
makeBaseApp.pl -t example testIoc
makeBaseApp.pl -i -t example testIoc
make
cd iocBoot/ioctestIoc
chmod u+x st.cmd
ioctestIoc> ./st.cmd
#!../../bin/darwin-x86/testIoc
< envPaths
```

and the students type out this line : "ioctestIoc> ./st.cmd”
and thereby overwrite st.cmd ;-)

It would be good if “ioctestIoc>” could be removed here …. 
Danke