### PR TITLE
Add the NTStructure

### DIFF
--- a/pv-access/Normative-Types-Specification.rst
+++ b/pv-access/Normative-Types-Specification.rst
@@ -2380,6 +2380,30 @@ nanoseconds
 userTag
    The ``userTag`` field of the timestamp associated with each channel.
 
+NTStructure
+~~~~~~~~~~~
+
+NTStructure is the EPICS V4 Normative Type that describes a structured set of fields.
+It is the type that is currently supported to be archived in the EPICS Archiver Appliance,
+and is presented in the details page as type DBR_V4_GENERIC_BYTES.
+
+
+::
+
+   NTStructure :=
+
+   structure
+       structure_t    value
+       alarm_t     alarm       :opt
+       time_t      timeStamp   :opt
+
+where:
+
+value
+   The primary data carried by the NTStructure object. The field must be
+   named "value" and can be of any simple structure type as defined above.
+
+
 Appendix B: Normative Type Identifiers
 --------------------------------------
 

--- a/pv-access/Normative-Types-Specification.rst
+++ b/pv-access/Normative-Types-Specification.rst
@@ -2384,9 +2384,11 @@ NTStructure
 ~~~~~~~~~~~
 
 NTStructure is the EPICS V4 Normative Type that describes a structured set of fields.
-It is the type that is currently supported to be archived in the EPICS Archiver Appliance,
-and is presented in the details page as type DBR_V4_GENERIC_BYTES.
+In some sense it is a supertype of many of the other Normative Types.
 
+Use cases: Currently used in the EPICS Archiver Appliance for archiving structured data 
+with the prerequisite that the timestamp is required. The archiver type displyed in the Archiver
+when it has determined a PV to be of this type is DBR_V4_GENERIC_BYTES.
 
 ::
 
@@ -2394,7 +2396,7 @@ and is presented in the details page as type DBR_V4_GENERIC_BYTES.
 
    structure
        structure_t    value
-       time_t      timeStamp
+       time_t      timeStamp   :opt
        alarm_t     alarm       :opt
 
 where:
@@ -2402,6 +2404,10 @@ where:
 value
    The primary data carried by the NTStructure object. The field must be
    named "value" and can be of any simple structure type as defined above.
+alarm
+   The alarm associated with the NTStructure itself.
+timeStamp
+   The timestamp associated with the NTStructure.
 
 
 Appendix B: Normative Type Identifiers

--- a/pv-access/Normative-Types-Specification.rst
+++ b/pv-access/Normative-Types-Specification.rst
@@ -2394,8 +2394,8 @@ and is presented in the details page as type DBR_V4_GENERIC_BYTES.
 
    structure
        structure_t    value
+       time_t      timeStamp
        alarm_t     alarm       :opt
-       time_t      timeStamp   :opt
 
 where:
 


### PR DESCRIPTION
This actually suprsumes the NTScalar and NTScalarArray types.

Looking for feedback, I think its best this is documented here and then referenced in the archiver documentation.

Note at the moment that the EPICS Archiver Appliance ignores the type name (so it doesn't care if it says NTScalar/1.0 etc). 